### PR TITLE
Architecture was missing for createVectorDB method

### DIFF
--- a/lib/rag-sources/aurora-pgvector/index.ts
+++ b/lib/rag-sources/aurora-pgvector/index.ts
@@ -62,7 +62,7 @@ export class AuroraPgVector extends Construct {
       });
     }
 
-    const { dbCluster } = this.createVectorDB({ vpc, indexTypes });
+    const { dbCluster } = this.createVectorDB({ vpc, indexTypes, architecture });
     const { embeddingsEndpoint } = this.createEmbeddingsEndpoint({ vpc });
     const documentIndexing = new DocumentIndexing(this, 'DocumentIndexing', {
       vpc,
@@ -75,7 +75,7 @@ export class AuroraPgVector extends Construct {
     this.createAPI({ vpc, dbCluster, embeddingsEndpoint: embeddingsEndpoint, runtime, architecture });
   }
 
-  private createVectorDB({ vpc, indexTypes }: { vpc: ec2.Vpc; indexTypes: PGVectorIndexType[] }) {
+  private createVectorDB({ vpc, indexTypes, architecture}: { vpc: ec2.Vpc; indexTypes: PGVectorIndexType[], architecture: lambda.Architecture}) {
     const dbCluster = new rds.DatabaseCluster(this, 'AuroraDatabase', {
       engine: rds.DatabaseClusterEngine.auroraPostgres({
         version: rds.AuroraPostgresEngineVersion.VER_15_3,


### PR DESCRIPTION
Compile time error as the databaseSetupFunction needs architecture

*Issue #, if available:*

*Description of changes:* Modified method to add the architecture for databaseSetupFunction lambda


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
