### PR TITLE
Add pydantic to kendra-serach common requirements to avoid importing …

### DIFF
--- a/lib/rag-sources/kendra-search/layers/common/requirements.txt
+++ b/lib/rag-sources/kendra-search/layers/common/requirements.txt
@@ -1,3 +1,4 @@
 aws_lambda_powertools
 aws_xray_sdk
+pydantic
 langchain


### PR DESCRIPTION
This solves issue where the KendraSearchApi Lambda fails for `[ERROR] Runtime.ImportModuleError: Unable to import module 'index': No module named 'pydantic_core._pydantic_core'`.

Adding pydantic to KendraSearchCommonLayer seem to do the trick.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
