### PR TITLE
Add support for Azure OpenAI, Palm, Replicate, Sagemaker (100+LLMs) - using litellm

### DIFF
--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/openai/gpt.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/openai/gpt.py
@@ -1,6 +1,6 @@
 import os
 
-from langchain.chat_models import ChatOpenAI
+from langchain.chat_models import ChatLiteLLM
 
 from ..base import ModelAdapter
 from ..registry import registry
@@ -15,8 +15,8 @@ class GPTAdapter(ModelAdapter):
     def get_llm(self, model_kwargs={}):
         if not os.environ.get("OPENAI_API_KEY"):
             raise Exception("OPENAI_API_KEY must be set in the environment")
-
-        return ChatOpenAI(model_name=self.model_id, temperature=0, **model_kwargs)
+        # use 100+ LLMs simply pass in the LLM as model_name
+        return ChatLiteLLM(model_name=self.model_id, temperature=0, **model_kwargs)
 
 
 # Register the adapter


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/aws-genai-llm-chatbot/issues/28

*Description of changes:*
This PR adds support for 50+ models with a standard I/O interface using: https://github.com/BerriAI/litellm/

`ChatLiteLLM()` is integrated into langchain and allows you to call all models using the `ChatOpenAI` I/O interface 
https://python.langchain.com/docs/integrations/chat/litellm

Here's an example of how to use ChatLiteLLM()
```python
ChatLiteLLM(model="gpt-3.5-turbo")
ChatLiteLLM(model="claude-2", temperature=0.3)
ChatLiteLLM(model="command-nightly")
ChatLiteLLM(model="replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1")

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
