### PR TITLE
Added _language_code attribute filter to AmazonKendraRetriever

### DIFF
--- a/lib/rag-sources/aurora-pgvector/functions/document-indexing/requirements.txt
+++ b/lib/rag-sources/aurora-pgvector/functions/document-indexing/requirements.txt
@@ -1,6 +1,6 @@
 aws_lambda_powertools
 aws_xray_sdk
-langchain
+langchain==0.0.288
 psycopg2-binary
 pgvector
-unstructured[all-docs]
+unstructured[all-docs]==0.10.14

--- a/lib/rag-sources/kendra-search/functions/api-handler/index.py
+++ b/lib/rag-sources/kendra-search/functions/api-handler/index.py
@@ -17,7 +17,18 @@ def get_relevant_documents():
     query: dict = app.current_event.json_body.get("query")
     logger.info(query)
 
-    retriever = AmazonKendraRetriever(index_id=os.environ["KENDRA_INDEX_ID"], top_k=3)
+    retriever = AmazonKendraRetriever(
+        index_id=os.environ["KENDRA_INDEX_ID"], 
+        top_k=3, 
+        attribute_filter={
+            "EqualsTo": {      
+                "Key": "_language_code",
+                "Value": {
+                    "StringValue": os.environ["KENDRA_LANGUAGE_CODE"]
+                }
+            }
+        }
+    )
     docs = retriever.get_relevant_documents(query)
     logger.info(docs)
 

--- a/lib/rag-sources/kendra-search/index.ts
+++ b/lib/rag-sources/kendra-search/index.ts
@@ -106,6 +106,7 @@ export class KendraSearch extends Construct {
       layers: [commonLayer.layer],
       environment: {
         KENDRA_INDEX_ID: index.ref,
+        KENDRA_LANGUAGE_CODE: 'en',
       },
     });
 

--- a/lib/rag-sources/opensearch-vectorsearch/functions/index-document/requirements.txt
+++ b/lib/rag-sources/opensearch-vectorsearch/functions/index-document/requirements.txt
@@ -2,7 +2,7 @@ aws_lambda_powertools
 aws_xray_sdk
 boto3-1.28.21-py3-none-any.whl
 botocore-1.31.21-py3-none-any.whl
-langchain
+langchain==0.0.288
 opensearch-py
 requests_aws4auth
-unstructured[all-docs]
+unstructured[all-docs]==0.10.14


### PR DESCRIPTION
*Description of changes:*
`rag-source` for KENDRA only supports English language indexed documents due to the lack of interface to configure an `attribute_filter` in `AmazonKendraRetriever()`. While the ideal solution would be to add language configuration in the UI, this is a stopgap solution that adds `KENDRA_LANGUAGE_CODE` environment variable to the `api-handler` Lambda function, that will be subsequently used as an _attribute_filter_ in `AmazonKendraRetriever` call. Without any `attribute_filter` in the call, KENDRA defaults to discard non-English documents.

To avoid any any disruption in the current solution behaviour, `KENDRA_LANGUAGE_CODE` defaults to `en`, so users of the sample won't notice any change unless explicitly change variable value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
