### PR TITLE
feat: possibility to override the Retrieve prompts

### DIFF
--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/base/base.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/base/base.py
@@ -6,6 +6,7 @@ from langchain.chains import ConversationalRetrievalChain, ConversationChain
 from langchain.memory import ConversationBufferMemory
 from langchain.prompts.prompt import PromptTemplate
 from genai_core.langchain import WorkspaceRetriever, DynamoDBChatMessageHistory
+from langchain.chains.conversational_retrieval.prompts import QA_PROMPT, CONDENSE_QUESTION_PROMPT
 
 logger = Logger()
 
@@ -74,6 +75,12 @@ class ModelAdapter:
         prompt_template = PromptTemplate(**prompt_template_args)
 
         return prompt_template
+    
+    def get_condense_question_prompt(self):
+        return CONDENSE_QUESTION_PROMPT
+
+    def get_qa_prompt(self):
+        return QA_PROMPT
 
     def run_with_chain(self, user_prompt, workspace_id=None):
         if not self.llm:
@@ -83,6 +90,8 @@ class ModelAdapter:
             conversation = ConversationalRetrievalChain.from_llm(
                 self.llm,
                 WorkspaceRetriever(workspace_id=workspace_id),
+                condense_question_prompt=self.get_condense_question_prompt(),
+                combine_docs_chain_kwargs={"prompt": self.get_qa_prompt()},
                 return_source_documents=True,
                 memory=self.get_memory(output_key="answer"),
                 verbose=True,

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/ai21_j2.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/ai21_j2.py
@@ -33,12 +33,12 @@ class AI21J2Adapter(ModelAdapter):
     def get_prompt(self):
         template = """Human: The following is a friendly conversation between a human and an AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know.
 
-        Current conversation:
-        {chat_history}
+Current conversation:
+{chat_history}
 
-        Question: {input}
-        
-        Assistant:"""
+Question: {input}
+
+Assistant:"""
 
         input_variables = ["input", "chat_history"]
         prompt_template_args = {

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/claude.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/claude.py
@@ -1,8 +1,7 @@
 import genai_core.clients
 
+from langchain.llms import Bedrock
 from langchain.prompts.prompt import PromptTemplate
-
-from langchain.chat_models import BedrockChat
 
 from ..base import ModelAdapter
 from ..registry import registry
@@ -25,23 +24,40 @@ class BedrockClaudeAdapter(ModelAdapter):
         if "maxTokens" in model_kwargs:
             params["max_tokens_to_sample"] = model_kwargs["maxTokens"]
 
-        return BedrockChat(
-            client=bedrock,
+        return Bedrock(
+            client=client,
             model_id=self.model_id,
             model_kwargs=params,
             streaming=model_kwargs.get("streaming", False),
             callbacks=[self.callback_handler],
         )
 
+    def get_qa_prompt(self):
+        template = """
+
+Human: Use the following pieces of context to answer the question at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer.
+
+{context}
+
+Question: {question}
+
+Assistant:"""
+
+        return PromptTemplate(
+                template=template, input_variables=["context", "question"]
+                )
+
     def get_prompt(self):
-        template = """Human: The following is a friendly conversation between a human and an AI. If the AI does not know the answer to a question, it truthfully says it does not know.
+        template = """
 
-        Current conversation:
-        {chat_history}
+Human: The following is a friendly conversation between a human and an AI. If the AI does not know the answer to a question, it truthfully says it does not know.
 
-        Question: {input}
-        
-        Assistant:"""
+Current conversation:
+{chat_history}
+
+Question: {input}
+
+Assistant:"""
 
         input_variables = ["input", "chat_history"]
         prompt_template_args = {
@@ -52,6 +68,21 @@ class BedrockClaudeAdapter(ModelAdapter):
         prompt_template = PromptTemplate(**prompt_template_args)
 
         return prompt_template
+
+    def get_condense_question_prompt(self):
+        template = """
+Human: Given the following conversation and a follow up question, rephrase the follow up question to be a standalone question, in its original language.
+
+Chat History:
+{chat_history}
+Follow Up Input: {question}
+
+Assistant:"""
+
+        return PromptTemplate(input_variables=["chat_history", "question"],
+                            chat_history="{chat_history}",
+                            template=template)
+
 
 
 # Register the adapter

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/claude.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/claude.py
@@ -25,7 +25,7 @@ class BedrockClaudeAdapter(ModelAdapter):
             params["max_tokens_to_sample"] = model_kwargs["maxTokens"]
 
         return Bedrock(
-            client=client,
+            client=bedrock,
             model_id=self.model_id,
             model_kwargs=params,
             streaming=model_kwargs.get("streaming", False),

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/titan.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/titan.py
@@ -35,12 +35,12 @@ class BedrockTitanAdapter(ModelAdapter):
     def get_prompt(self):
         template = """Human: The following is a friendly conversation between a human and an AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know.
 
-        Current conversation:
-        {chat_history}
+Current conversation:
+{chat_history}
 
-        Question: {input}
-        
-        Assistant:"""
+Question: {input}
+
+Assistant:"""
 
         input_variables = ["input", "chat_history"]
         prompt_template_args = {


### PR DESCRIPTION
*Issue #, if available:*
#55 

*Description of changes:*
RAG uses langchain `ConversationalRetrievalChain` and with this change we allow to override the 2 prompts used by this chain this fixes the issue with the specific Claude formatting but also allows for further prompt tuning if necessary

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
