### PR TITLE
Grant bedrock:InvokeModel permissions to FileImport Lambda so it can …

### DIFF
--- a/lib/rag-engines/data-import/file-import-workflow.ts
+++ b/lib/rag-engines/data-import/file-import-workflow.ts
@@ -46,7 +46,7 @@ export class FileImportWorkflow extends Construct {
         props.shared.commonLayer.layer,
         props.shared.pythonSDKLayer,
       ],
-      timeout: cdk.Duration.minutes(10),
+      timeout: cdk.Duration.minutes(15),
       logRetention: logs.RetentionDays.ONE_WEEK,
       environment: {
         ...props.shared.defaultEnvironmentVariables,
@@ -110,6 +110,15 @@ export class FileImportWorkflow extends Construct {
           resources: [props.sageMakerRagModelsEndpoint.ref],
         })
       );
+    }
+    
+    if(props.config.bedrock?.enabled === true) {
+      dataImportFunction.addToRolePolicy(
+        new iam.PolicyStatement({
+          actions: ["bedrock:InvokeModel"],
+          resources: ["*"],
+        })
+      );      
     }
 
     if (props.config.bedrock?.roleArn) {


### PR DESCRIPTION
…access Titan embeddings

Also, set the lambda's timeout to 15 minutes to support large documents.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
