### PR TITLE
Fix too long resource name

### DIFF
--- a/lib/rag-engines/index.ts
+++ b/lib/rag-engines/index.ts
@@ -40,7 +40,7 @@ export class RagEngines extends Construct {
 
     const sageMakerRagModels = new SageMakerRagModels(
       this,
-      "SageMakerRagModels",
+      "SMRagModels",
       {
         shared: props.shared,
         config: props.config,

--- a/lib/rag-engines/index.ts
+++ b/lib/rag-engines/index.ts
@@ -40,7 +40,7 @@ export class RagEngines extends Construct {
 
     const sageMakerRagModels = new SageMakerRagModels(
       this,
-      "SMRagModels",
+      "SageMaker",
       {
         shared: props.shared,
         config: props.config,

--- a/lib/sagemaker-model/deploy-custom-script-model.ts
+++ b/lib/sagemaker-model/deploy-custom-script-model.ts
@@ -2,6 +2,7 @@ import { Construct } from "constructs";
 
 import { HuggingFaceCustomScriptModel } from "./hf-custom-script-model";
 import { SageMakerModelProps, ModelCustomScriptConfig } from "./types";
+import { createHash } from "crypto";
 
 export function deployCustomScriptModel(
   scope: Construct,
@@ -11,7 +12,15 @@ export function deployCustomScriptModel(
   const { vpc, region } = props;
   const { modelId, instanceType, codeFolder, container, env } = modelConfig;
 
-  const endpointName = (Array.isArray(modelId) ? modelId.join(",") : modelId)
+  const endpointName = (
+    Array.isArray(modelId)
+      ? `Multi${createHash("md5")
+          .update(modelId.join(","))
+          .digest("hex")
+          .toUpperCase()
+          .slice(-5)}`
+      : modelId
+  )
     .replace(/[^a-zA-Z0-9]/g, "")
     .slice(-10);
   const llmModel = new HuggingFaceCustomScriptModel(scope, endpointName, {

--- a/lib/sagemaker-model/deploy-custom-script-model.ts
+++ b/lib/sagemaker-model/deploy-custom-script-model.ts
@@ -13,7 +13,7 @@ export function deployCustomScriptModel(
 
   const endpointName = (Array.isArray(modelId) ? modelId.join(",") : modelId)
     .replace(/[^a-zA-Z0-9]/g, "")
-    .slice(-20);
+    .slice(-10);
   const llmModel = new HuggingFaceCustomScriptModel(scope, endpointName, {
     vpc,
     region,

--- a/lib/sagemaker-model/hf-custom-script-model/index.ts
+++ b/lib/sagemaker-model/hf-custom-script-model/index.ts
@@ -49,14 +49,14 @@ export class HuggingFaceCustomScriptModel extends Construct {
       ? props.modelId.join(",")
       : props.modelId;
 
-    const buildBucket = new s3.Bucket(this, "BuildBucket", {
+    const buildBucket = new s3.Bucket(this, "Bucket", {
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
       removalPolicy: cdk.RemovalPolicy.DESTROY,
       autoDeleteObjects: true,
     });
 
     // Upload build code to S3
-    new s3deploy.BucketDeployment(this, "BuildScriptDeployment", {
+    new s3deploy.BucketDeployment(this, "Script", {
       sources: [s3deploy.Source.asset(path.join(__dirname, "./build-script"))],
       retainOnDelete: false,
       destinationBucket: buildBucket,
@@ -66,7 +66,7 @@ export class HuggingFaceCustomScriptModel extends Construct {
     let deployment;
     // Upload model folder to S3
     if (codeFolder) {
-      deployment = new s3deploy.BucketDeployment(this, "ModelCodeDeployment", {
+      deployment = new s3deploy.BucketDeployment(this, "ModelCode", {
         sources: [s3deploy.Source.asset(codeFolder)],
         retainOnDelete: false,
         destinationBucket: buildBucket,


### PR DESCRIPTION
*Issue #, if available:*
Fix #122 

*Description of changes:*
Nested CDK constructs names get concatenated and if no resource name is specified in the construct the CDK construct name is used. This might cause some resource identifiers, such as ARNs to exceed the allowed length. 
This fix reduces the length of few known resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
