### PR TITLE
Fix broken link to AWS Console

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Before you begin using the solution, there are certain precautions you must take
 # Amazon SageMaker requirements (for self-hosted models only)
 **Instance type quota increase**
 
-If you are looking to self-host models on Amazon SageMaker, you'll likely need to request an increase in service quota for specific SageMaker instance types, such as the `ml.g5` instance type. This will give access to the latest generation of GPU/Multi-GPU instance types. [You can do this from the AWS console](console.aws.amazon.com/servicequotas/home/services/sagemaker/quotas)
+If you are looking to self-host models on Amazon SageMaker, you'll likely need to request an increase in service quota for specific SageMaker instance types, such as the `ml.g5` instance type. This will give access to the latest generation of GPU/Multi-GPU instance types. [You can do this from the AWS console](https://console.aws.amazon.com/servicequotas/home/services/sagemaker/quotas)
 
 # Amazon Bedrock requirements
 **Base Models Access**


### PR DESCRIPTION
Fix broken link to Sagemaker quotas in AWS Console

*Issue #, if available:*
Link to console was not absolute.

*Description of changes:*
Added protocol to console link

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
