### PR TITLE
Fixed Claudev2 condensed question to be in the same language as the user input

### DIFF
--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/claude.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/claude.py
@@ -73,7 +73,7 @@ Assistant:"""
         template = """
 {chat_history}
 
-Human: Given the following conversation and a follow up question, rephrase the follow up question to be a standalone question, in its original language.
+Human: Given the above conversation and a follow up input, rephrase the follow up input to be a standalone question, in the same language as the follow up input.
 Follow Up Input: {question}
 
 Assistant:"""


### PR DESCRIPTION
Issue #194 

Changed Claude `get_condense_question_prompt` to make the condensed question generated in the same language as the user input.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.