### PR TITLE
fix(reranking): uses semantic search score

### DIFF
--- a/lib/shared/layers/python-sdk/python/genai_core/opensearch/query.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/opensearch/query.py
@@ -107,14 +107,14 @@ def query_workspace_open_search(
             unique_items[i]["score"] = score
             score_dict[unique_items[i]["chunk_id"]] = score
     unique_items = sorted(unique_items, key=lambda x: x["score"], reverse=True)
-    unique_items = unique_items[:limit]
-
+    
     for record in vector_search_records:
         record["score"] = score_dict[record["chunk_id"]]
     for record in keyword_search_records:
         record["score"] = score_dict[record["chunk_id"]]
 
     if full_response:
+        unique_items = unique_items[:limit]
         ret_value = {
             "engine": "opensearch",
             "supported_languages": languages,
@@ -124,14 +124,14 @@ def query_workspace_open_search(
             "keyword_search_items": keyword_search_records,
         }
     else:
-        ret_items = list(filter(lambda val: val["score"] > threshold, unique_items))
+        ret_items = list(filter(lambda val: val["score"] > threshold, unique_items))[:limit]
         if len(ret_items) < limit:
             unique_items = sorted(
-                unique_items, key=lambda x: x["vector_search_score"], reverse=True
+                unique_items, key=lambda x: x["vector_search_score"] or -1, reverse=True
             )
             ret_items = ret_items + (
                 list(
-                    filter(lambda val: val["vector_search_score"] > 0.5, unique_items)
+                    filter(lambda val: (val["vector_search_score"] or -1)  > 0.5, unique_items)
                 )[: (limit - len(ret_items))]
             )
 


### PR DESCRIPTION
Fills up the documents returned by the retriever with the top scored semantic search documents

*Issue #, if available:*

Fix #197
 
*Description of changes:*
The fill-up logic is changed so:
- only selects records that have a semantic search score and ignore other records
- for aurora takes into consideration that "inner" metric produces negative values
- correctly implements the filtering of the top-k items

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
