### PR TITLE
Bump langchain version batch to 0.0.331

### DIFF
--- a/lib/shared/file-import-batch-job/requirements.txt
+++ b/lib/shared/file-import-batch-job/requirements.txt
@@ -4,7 +4,7 @@ numpy==1.26.0
 cfnresponse==1.1.2
 aws_requests_auth==0.4.3
 requests-aws4auth==1.2.3
-langchain==0.0.308
+langchain==0.0.331
 opensearch-py==2.3.1
 psycopg2-binary==2.9.7
 pgvector==0.2.2


### PR DESCRIPTION
- Bump langchain version for file import jobs to `0.0.331`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
