### PR TITLE
docs: set up VitePress for documentation site hosted on GitHub pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,9 @@
 name: Deploy VitePress site to Pages
 
 on:
-  # Runs on pushes targeting the `gh_pages` branch. Should be default branch
+  # Runs on pushes targeting the `main` branch. Should be default branch
   push:
-    branches: [gh-pages]
+    branches: [main]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,61 @@
+name: Deploy VitePress site to Pages
+
+on:
+  # Runs on pushes targeting the `gh_pages` branch. Should be default branch
+  push:
+    branches: [gh-pages]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Not needed if lastUpdated is not enabled
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Install dependencies
+        run: npm ci
+      - name: Build with VitePress
+        run: |
+          npm run docs:build
+          touch docs/.vitepress/dist/.nojekyll
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: docs/.vitepress/dist
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    name: Deploy
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.gitignore
+++ b/.gitignore
@@ -441,3 +441,7 @@ venv
 lib/user-interface/react-app/public/aws-exports.json
 out.tmp
 bin/config.json
+
+# Docs
+docs/.vitepress/cache
+docs/.vitepress/dist

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitepress'
+
+// https://vitepress.dev/reference/site-config
+export default defineConfig({
+  title: "AWS GenAI LLM Chatbot",
+  description: "Deploying a Multi-Model and Multi-RAG Powered Chatbot Using AWS CDK on AWS",
+  base: "/aws-genai-llm-chatbot/",
+  themeConfig: {
+    // https://vitepress.dev/reference/default-theme-config
+    nav: [
+      { text: 'Home', link: '/' },
+      { text: 'GitHub', link: 'https://github.com/aws-samples/aws-genai-llm-chatbot' }
+    ],
+  }
+})

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,12 @@
+---
+layout: home
+
+hero:
+  name: "AWS GenAI LLM Chatbot"
+  text: "Deploying a Multi-Model and Multi-RAG Powered Chatbot Using AWS CDK on AWS"
+  actions:
+    - theme: brand
+      text: View on GitHub
+      link: https://github.com/aws-samples/aws-genai-llm-chatbot
+---
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
         "eslint": "^8.45.0",
         "prettier": "^3.0.3",
         "ts-node": "^10.9.1",
-        "typescript": "~5.1.3"
+        "typescript": "~5.1.3",
+        "vitepress": "^1.0.0-rc.24"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -45,6 +46,180 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
+      "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
+        "@algolia/autocomplete-shared": "1.9.3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
+      "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.9.3"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
+      "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.9.3"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
+      "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/cache-browser-local-storage": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.20.0.tgz",
+      "integrity": "sha512-uujahcBt4DxduBTvYdwO3sBfHuJvJokiC3BP1+O70fglmE1ShkH8lpXqZBac1rrU3FnNYSUs4pL9lBdTKeRPOQ==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/cache-common": "4.20.0"
+      }
+    },
+    "node_modules/@algolia/cache-common": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.20.0.tgz",
+      "integrity": "sha512-vCfxauaZutL3NImzB2G9LjLt36vKAckc6DhMp05An14kVo8F1Yofb6SIl6U3SaEz8pG2QOB9ptwM5c+zGevwIQ==",
+      "dev": true
+    },
+    "node_modules/@algolia/cache-in-memory": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.20.0.tgz",
+      "integrity": "sha512-Wm9ak/IaacAZXS4mB3+qF/KCoVSBV6aLgIGFEtQtJwjv64g4ePMapORGmCyulCFwfePaRAtcaTbMcJF+voc/bg==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/cache-common": "4.20.0"
+      }
+    },
+    "node_modules/@algolia/client-account": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.20.0.tgz",
+      "integrity": "sha512-GGToLQvrwo7am4zVkZTnKa72pheQeez/16sURDWm7Seyz+HUxKi3BM6fthVVPUEBhtJ0reyVtuK9ArmnaKl10Q==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "4.20.0",
+        "@algolia/client-search": "4.20.0",
+        "@algolia/transporter": "4.20.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.20.0.tgz",
+      "integrity": "sha512-EIr+PdFMOallRdBTHHdKI3CstslgLORQG7844Mq84ib5oVFRVASuuPmG4bXBgiDbcsMLUeOC6zRVJhv1KWI0ug==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "4.20.0",
+        "@algolia/client-search": "4.20.0",
+        "@algolia/requester-common": "4.20.0",
+        "@algolia/transporter": "4.20.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.20.0.tgz",
+      "integrity": "sha512-P3WgMdEss915p+knMMSd/fwiHRHKvDu4DYRrCRaBrsfFw7EQHon+EbRSm4QisS9NYdxbS04kcvNoavVGthyfqQ==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/requester-common": "4.20.0",
+        "@algolia/transporter": "4.20.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.20.0.tgz",
+      "integrity": "sha512-N9+zx0tWOQsLc3K4PVRDV8GUeOLAY0i445En79Pr3zWB+m67V+n/8w4Kw1C5LlbHDDJcyhMMIlqezh6BEk7xAQ==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "4.20.0",
+        "@algolia/requester-common": "4.20.0",
+        "@algolia/transporter": "4.20.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.20.0.tgz",
+      "integrity": "sha512-zgwqnMvhWLdpzKTpd3sGmMlr4c+iS7eyyLGiaO51zDZWGMkpgoNVmltkzdBwxOVXz0RsFMznIxB9zuarUv4TZg==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "4.20.0",
+        "@algolia/requester-common": "4.20.0",
+        "@algolia/transporter": "4.20.0"
+      }
+    },
+    "node_modules/@algolia/logger-common": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.20.0.tgz",
+      "integrity": "sha512-xouigCMB5WJYEwvoWW5XDv7Z9f0A8VoXJc3VKwlHJw/je+3p2RcDXfksLI4G4lIVncFUYMZx30tP/rsdlvvzHQ==",
+      "dev": true
+    },
+    "node_modules/@algolia/logger-console": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.20.0.tgz",
+      "integrity": "sha512-THlIGG1g/FS63z0StQqDhT6bprUczBI8wnLT3JWvfAQDZX5P6fCg7dG+pIrUBpDIHGszgkqYEqECaKKsdNKOUA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/logger-common": "4.20.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.20.0.tgz",
+      "integrity": "sha512-HbzoSjcjuUmYOkcHECkVTwAelmvTlgs48N6Owt4FnTOQdwn0b8pdht9eMgishvk8+F8bal354nhx/xOoTfwiAw==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/requester-common": "4.20.0"
+      }
+    },
+    "node_modules/@algolia/requester-common": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.20.0.tgz",
+      "integrity": "sha512-9h6ye6RY/BkfmeJp7Z8gyyeMrmmWsMOCRBXQDs4mZKKsyVlfIVICpcSibbeYcuUdurLhIlrOUkH3rQEgZzonng==",
+      "dev": true
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.20.0.tgz",
+      "integrity": "sha512-ocJ66L60ABSSTRFnCHIEZpNHv6qTxsBwJEPfYaSBsLQodm0F9ptvalFkHMpvj5DfE22oZrcrLbOYM2bdPJRHng==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/requester-common": "4.20.0"
+      }
+    },
+    "node_modules/@algolia/transporter": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.20.0.tgz",
+      "integrity": "sha512-Lsii1pGWOAISbzeyuf+r/GPhvHMPHSPrTDWNcIzOE1SG1inlJHICaVe2ikuoRjcpgxZNU54Jl+if15SUCsaTUg==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/cache-common": "4.20.0",
+        "@algolia/logger-common": "4.20.0",
+        "@algolia/requester-common": "4.20.0"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
@@ -216,24 +391,24 @@
       "dev": true
     },
     "node_modules/@aws-lambda-powertools/batch": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/batch/-/batch-1.14.1.tgz",
-      "integrity": "sha512-ls69LDwk1m5A0V/oPn2BhPzaZr9znCtIH0Q4ofgCByxMYV+j3mNfrg1M44zcekvLQoZx+ldx2OpaV5Cv9HisxA==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/batch/-/batch-1.14.2.tgz",
+      "integrity": "sha512-WRaCPyDvF8wG5vWvoDbDlzZf5dCa/3bYCCi7ihm7+mD6D/zqnjT1HNzfQDCSvMo3yE+wdx+yCLpp7Vvy5berOw==",
       "dev": true
     },
     "node_modules/@aws-lambda-powertools/commons": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-1.14.1.tgz",
-      "integrity": "sha512-nJ9NFOJj2qnZzdQT5bdixkkZughpEap/9PmZKeHTRffofR79Cf5/YGSadul2pijT6T+pqUfmarY1+I9WJMw+JQ==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-1.14.2.tgz",
+      "integrity": "sha512-pGW2RSeOEbU1e+mj+MlMkaiM4njO289glFjJA1V+H8bmjvHJXaItroH7lutZ8Gde1Iq+5WoRVQN8M/xmMNSxIA==",
       "dev": true
     },
     "node_modules/@aws-lambda-powertools/logger": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-1.14.1.tgz",
-      "integrity": "sha512-R882S+sgZ7ujrwG6HxoqAhINtH7sNWT80KRITYRPcci5hxlX86CF98vKeOtjpsWfK3KeHwTv3vG6MbRr5DEHOw==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-1.14.2.tgz",
+      "integrity": "sha512-eUu1qF/8S3H7SquaKjmIj/go/3UDYwsfiJ3My1gtqd9eKRlUPKpvktAeF/+yghcO0BmuA5q1i2hKr8rsJ+2lGg==",
       "dev": true,
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^1.14.1",
+        "@aws-lambda-powertools/commons": "^1.14.2",
         "lodash.merge": "^4.6.2"
       },
       "peerDependencies": {
@@ -246,14 +421,14 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.441.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.441.0.tgz",
-      "integrity": "sha512-gndGymu4cEIN7WWhQ67RO0JMda09EGBlay2L8IKCHBK/65Y34FHUX1tCNbO2qezEzsi6BPW5o2n53Rd9QqpHUw==",
+      "version": "3.445.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.445.0.tgz",
+      "integrity": "sha512-me4LvqNnu6kxi+sW7t0AgMv1Yi64ikas0x2+5jv23o6Csg32w0S0xOjCTKQYahOA5CMFunWvlkFIfxbqs+Uo7w==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.441.0",
+        "@aws-sdk/core": "3.445.0",
         "@aws-sdk/middleware-host-header": "3.433.0",
         "@aws-sdk/middleware-logger": "3.433.0",
         "@aws-sdk/middleware-recursion-detection": "3.433.0",
@@ -292,76 +467,14 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/is-array-buffer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/protocol-http": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
-      "integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-buffer-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-utf8": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
-      "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/core": {
-      "version": "3.441.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.441.0.tgz",
-      "integrity": "sha512-gV0eQwR0VnSPUYAbgDkbBtfXbSpZgl/K6UB13DP1IFFjQYbF/BxYwvcQe4jHoPOBifSgjEbl8MfOOeIyI7k9vg==",
+      "version": "3.445.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.445.0.tgz",
+      "integrity": "sha512-6GYLElUG1QTOdmXG8zXa+Ull9IUeSeItKDYHKzHYfIkbsagMfYlf7wm9XIYlatjtgodNfZ3gPHAJfRyPmwKrsg==",
       "dev": true,
       "dependencies": {
-        "@smithy/smithy-client": "^2.1.12"
+        "@smithy/smithy-client": "^2.1.12",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -382,45 +495,21 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.441.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.441.0.tgz",
-      "integrity": "sha512-SQipQYxYqDUuSOfIhDmaTdwPTcndGQotGZXWJl56mMWqAhU8MkwjK+oMf3VgRt/umJC0QwUCF5HUHIj7gSB1JA==",
+      "version": "3.445.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.445.0.tgz",
+      "integrity": "sha512-R7IYSGjNZ5KKJwQJ2HNPemjpAMWvdce91i8w+/aHfqeGfTXrmYJu99PeGRyyBTKEumBaojyjTRvmO8HzS+/l7g==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.433.0",
         "@aws-sdk/credential-provider-process": "3.433.0",
-        "@aws-sdk/credential-provider-sso": "3.441.0",
+        "@aws-sdk/credential-provider-sso": "3.445.0",
         "@aws-sdk/credential-provider-web-identity": "3.433.0",
         "@aws-sdk/types": "3.433.0",
         "@smithy/credential-provider-imds": "^2.0.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
         "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -428,33 +517,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.441.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.441.0.tgz",
-      "integrity": "sha512-WB9p37yHq6fGJt6Vll29ijHbkh9VDbPM/n5ns73bTAgFD7R0ht5kPmdmHGQA6m3RKjcHLPbymQ3lXykkMwWf/Q==",
+      "version": "3.445.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.445.0.tgz",
+      "integrity": "sha512-zI4k4foSjQRKNEsouculRcz7IbLfuqdFxypDLYwn+qPNMqJwWJ7VxOOeBSPUpHFcd7CLSfbHN2JAhQ7M02gPTA==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.433.0",
-        "@aws-sdk/credential-provider-ini": "3.441.0",
+        "@aws-sdk/credential-provider-ini": "3.445.0",
         "@aws-sdk/credential-provider-process": "3.433.0",
-        "@aws-sdk/credential-provider-sso": "3.441.0",
+        "@aws-sdk/credential-provider-sso": "3.445.0",
         "@aws-sdk/credential-provider-web-identity": "3.433.0",
         "@aws-sdk/types": "3.433.0",
         "@smithy/credential-provider-imds": "^2.0.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
         "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -477,42 +554,18 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.441.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.441.0.tgz",
-      "integrity": "sha512-pTg16G+62mWCE8yGKuQnEBqPdpG5g71remf2jUqXaI1c7GCzbnkQDV9eD4DaAGOvzIs0wo9zAQnS2kVDPFlCYA==",
+      "version": "3.445.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.445.0.tgz",
+      "integrity": "sha512-gJz7kAiDecdhtApgXnxfZsXKsww8BnifDF9MAx9Dr4X6no47qYsCCS3XPuEyRiF9VebXvHOH0H260Zp3bVyniQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.441.0",
+        "@aws-sdk/client-sso": "3.445.0",
         "@aws-sdk/token-providers": "3.438.0",
         "@aws-sdk/types": "3.433.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
         "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -534,18 +587,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.433.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.433.0.tgz",
@@ -555,31 +596,6 @@
         "@aws-sdk/types": "3.433.0",
         "@smithy/protocol-http": "^3.0.8",
         "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-host-header/node_modules/@smithy/protocol-http": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
-      "integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-host-header/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -600,18 +616,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-logger/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
       "version": "3.433.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.433.0.tgz",
@@ -621,31 +625,6 @@
         "@aws-sdk/types": "3.433.0",
         "@smithy/protocol-http": "^3.0.8",
         "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@smithy/protocol-http": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
-      "integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -668,31 +647,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/protocol-http": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
-      "integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/protocol-http": {
       "version": "3.374.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.374.0.tgz",
@@ -701,6 +655,31 @@
       "dev": true,
       "dependencies": {
         "@smithy/protocol-http": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http/node_modules/@smithy/protocol-http": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
+      "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -717,31 +696,6 @@
         "@smithy/types": "^2.4.0",
         "@smithy/util-config-provider": "^2.0.0",
         "@smithy/util-middleware": "^2.0.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/region-config-resolver/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/region-config-resolver/node_modules/@smithy/util-middleware": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.5.tgz",
-      "integrity": "sha512-1lyT3TcaMJQe+OFfVI+TlomDkPuVzb27NZYdYtmSTltVmLaUjdCyt4KE+OH1CnhZKsz4/cdCL420Lg9UH5Z2Mw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -810,69 +764,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/token-providers/node_modules/@smithy/is-array-buffer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers/node_modules/@smithy/protocol-http": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
-      "integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers/node_modules/@smithy/util-buffer-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers/node_modules/@smithy/util-utf8": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
-      "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/types": {
       "version": "3.433.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
@@ -880,18 +771,6 @@
       "dev": true,
       "dependencies": {
         "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/types/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -936,18 +815,6 @@
         "tslib": "^2.5.0"
       }
     },
-    "node_modules/@aws-sdk/util-user-agent-browser/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-user-agent-node": {
       "version": "3.437.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.437.0.tgz",
@@ -971,18 +838,6 @@
         }
       }
     },
-    "node_modules/@aws-sdk/util-user-agent-node/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-utf8-browser": {
       "version": "3.259.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
@@ -990,6 +845,18 @@
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1000,6 +867,70 @@
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.5.2.tgz",
+      "integrity": "sha512-SPiDHaWKQZpwR2siD0KQUwlStvIAnEyK6tAE2h2Wuoq8ue9skzhlyVQ1ddzOxX6khULnAALDiR/isSF3bnuciA==",
+      "dev": true
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.5.2.tgz",
+      "integrity": "sha512-p1YFTCDflk8ieHgFJYfmyHBki1D61+U9idwrLh+GQQMrBSP3DLGKpy0XUJtPjAOPltcVbqsTjiPFfH7JImjUNg==",
+      "dev": true,
+      "dependencies": {
+        "@docsearch/react": "3.5.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.5.2.tgz",
+      "integrity": "sha512-9Ahcrs5z2jq/DcAvYtvlqEBHImbm4YJI8M9y0x6Tqg598P40HTEkX7hsMcIuThI+hTFxRGZ9hll0Wygm2yEjng==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.9.3",
+        "@algolia/autocomplete-preset-algolia": "1.9.3",
+        "@docsearch/css": "3.5.2",
+        "algoliasearch": "^4.19.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
       "engines": {
         "node": ">=12"
       }
@@ -1166,18 +1097,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/abort-controller/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/config-resolver": {
       "version": "2.0.16",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.16.tgz",
@@ -1188,31 +1107,6 @@
         "@smithy/types": "^2.4.0",
         "@smithy/util-config-provider": "^2.0.0",
         "@smithy/util-middleware": "^2.0.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/config-resolver/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/config-resolver/node_modules/@smithy/util-middleware": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.5.tgz",
-      "integrity": "sha512-1lyT3TcaMJQe+OFfVI+TlomDkPuVzb27NZYdYtmSTltVmLaUjdCyt4KE+OH1CnhZKsz4/cdCL420Lg9UH5Z2Mw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1235,18 +1129,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/credential-provider-imds/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/eventstream-codec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.1.0.tgz",
@@ -1257,6 +1139,18 @@
         "@smithy/types": "^1.2.0",
         "@smithy/util-hex-encoding": "^1.1.0",
         "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
@@ -1270,31 +1164,6 @@
         "@smithy/types": "^2.4.0",
         "@smithy/util-base64": "^2.0.0",
         "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/protocol-http": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
-      "integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/hash-node": {
@@ -1312,56 +1181,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/hash-node/node_modules/@smithy/is-array-buffer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-node/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-node/node_modules/@smithy/util-buffer-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-node/node_modules/@smithy/util-utf8": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
-      "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/invalid-dependency": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.12.tgz",
@@ -1370,18 +1189,6 @@
       "dependencies": {
         "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@smithy/invalid-dependency/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/is-array-buffer": {
@@ -1410,31 +1217,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/middleware-content-length/node_modules/@smithy/protocol-http": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
-      "integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-content-length/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/middleware-endpoint": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.1.3.tgz",
@@ -1447,31 +1229,6 @@
         "@smithy/types": "^2.4.0",
         "@smithy/url-parser": "^2.0.12",
         "@smithy/util-middleware": "^2.0.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/util-middleware": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.5.tgz",
-      "integrity": "sha512-1lyT3TcaMJQe+OFfVI+TlomDkPuVzb27NZYdYtmSTltVmLaUjdCyt4KE+OH1CnhZKsz4/cdCL420Lg9UH5Z2Mw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1497,44 +1254,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/middleware-retry/node_modules/@smithy/protocol-http": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
-      "integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-retry/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-retry/node_modules/@smithy/util-middleware": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.5.tgz",
-      "integrity": "sha512-1lyT3TcaMJQe+OFfVI+TlomDkPuVzb27NZYdYtmSTltVmLaUjdCyt4KE+OH1CnhZKsz4/cdCL420Lg9UH5Z2Mw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/middleware-serde": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.12.tgz",
@@ -1542,18 +1261,6 @@
       "dev": true,
       "dependencies": {
         "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-serde/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1573,18 +1280,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/middleware-stack/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/node-config-provider": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.3.tgz",
@@ -1594,18 +1289,6 @@
         "@smithy/property-provider": "^2.0.13",
         "@smithy/shared-ini-file-loader": "^2.2.2",
         "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/node-config-provider/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1628,31 +1311,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/node-http-handler/node_modules/@smithy/protocol-http": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
-      "integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/node-http-handler/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/property-provider": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.13.tgz",
@@ -1666,25 +1324,13 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/property-provider/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/protocol-http": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
-      "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
+      "integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^1.2.0",
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1705,30 +1351,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/querystring-builder/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-builder/node_modules/@smithy/util-uri-escape": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
-      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/querystring-parser": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.12.tgz",
@@ -1736,18 +1358,6 @@
       "dev": true,
       "dependencies": {
         "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-parser/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1766,18 +1376,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/service-error-classification/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/shared-ini-file-loader": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.2.tgz",
@@ -1785,18 +1383,6 @@
       "dev": true,
       "dependencies": {
         "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/shared-ini-file-loader/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1822,6 +1408,68 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/util-buffer-from": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.1.0.tgz",
+      "integrity": "sha512-9m6NXE0ww+ra5HKHCHig20T+FAwxBAm7DIdwc/767uGWbRcY720ybgPacQNB96JMOI7xVr/CDa3oMzKmW4a+kw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/util-middleware": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.1.0.tgz",
+      "integrity": "sha512-6hhckcBqVgjWAqLy2vqlPZ3rfxLDhFWEmM7oLh2POGvsi7j0tHkbN7w4DFhuBExVJAbJ/qqxqZdRY6Fu7/OezQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/util-uri-escape": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.1.0.tgz",
+      "integrity": "sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/util-utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.1.0.tgz",
+      "integrity": "sha512-p/MYV+JmqmPyjdgyN2UxAeYDj9cBqCjp0C/NsTWnnjoZUVqoeZ6IrW915L9CAKWVECgv9lVQGc4u/yz26/bI1A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/smithy-client": {
       "version": "2.1.12",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.12.tgz",
@@ -1837,22 +1485,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/smithy-client/node_modules/@smithy/types": {
+    "node_modules/@smithy/types": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
       "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/types": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
-      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -1872,18 +1508,6 @@
         "tslib": "^2.5.0"
       }
     },
-    "node_modules/@smithy/url-parser/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/util-base64": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
@@ -1891,31 +1515,6 @@
       "dev": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-base64/node_modules/@smithy/is-array-buffer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-base64/node_modules/@smithy/util-buffer-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1944,12 +1543,24 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.1.0.tgz",
-      "integrity": "sha512-9m6NXE0ww+ra5HKHCHig20T+FAwxBAm7DIdwc/767uGWbRcY720ybgPacQNB96JMOI7xVr/CDa3oMzKmW4a+kw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
+      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
       "dev": true,
       "dependencies": {
-        "@smithy/is-array-buffer": "^1.1.0",
+        "@smithy/is-array-buffer": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
+      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1984,18 +1595,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@smithy/util-defaults-mode-browser/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/util-defaults-mode-node": {
       "version": "2.0.21",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.21.tgz",
@@ -2014,18 +1613,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@smithy/util-defaults-mode-node/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/util-endpoints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.2.tgz",
@@ -2038,18 +1625,6 @@
       },
       "engines": {
         "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-endpoints/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
@@ -2065,11 +1640,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.1.0.tgz",
-      "integrity": "sha512-6hhckcBqVgjWAqLy2vqlPZ3rfxLDhFWEmM7oLh2POGvsi7j0tHkbN7w4DFhuBExVJAbJ/qqxqZdRY6Fu7/OezQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.5.tgz",
+      "integrity": "sha512-1lyT3TcaMJQe+OFfVI+TlomDkPuVzb27NZYdYtmSTltVmLaUjdCyt4KE+OH1CnhZKsz4/cdCL420Lg9UH5Z2Mw==",
       "dev": true,
       "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2088,18 +1664,6 @@
       },
       "engines": {
         "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-retry/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-stream": {
@@ -2121,43 +1685,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/util-stream/node_modules/@smithy/is-array-buffer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream/node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream/node_modules/@smithy/util-buffer-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/util-stream/node_modules/@smithy/util-hex-encoding": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
@@ -2170,23 +1697,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
-      "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.1.0.tgz",
-      "integrity": "sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
+      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -2196,12 +1710,12 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.1.0.tgz",
-      "integrity": "sha512-p/MYV+JmqmPyjdgyN2UxAeYDj9cBqCjp0C/NsTWnnjoZUVqoeZ6IrW915L9CAKWVECgv9lVQGc4u/yz26/bI1A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
+      "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/util-buffer-from": "^1.1.0",
+        "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2233,15 +1747,37 @@
       "dev": true
     },
     "node_modules/@types/aws-lambda": {
-      "version": "8.10.125",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.125.tgz",
-      "integrity": "sha512-Vqw/WMlV4O1fJT6capim01v7VLDZkcX1n6Yhb52E7IfnMqYbNfwHfyDV8rRN42NLBtdDvfaqcCqs2K0fr5ljZw==",
+      "version": "8.10.126",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.126.tgz",
+      "integrity": "sha512-5eh4ffLdGYgGYI1Xr6W5L4IVse4RR7L2ns5OVUXA52nW5GFapIcGMcCzHAIMMOdpcQs3aGVxbvFlJNZH6IpgEQ==",
       "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.14",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.14.tgz",
       "integrity": "sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw==",
+      "dev": true
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.4.tgz",
+      "integrity": "sha512-hPpIeeHb/2UuCw06kSNAOVWgehBLXEo0/fUs0mw3W2qhqX89PI2yvok83MnuctYGCPrabGIoi0fFso4DQ+sNUQ==",
+      "dev": true
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.5.tgz",
+      "integrity": "sha512-QhJP7hkq3FCrFNx0szMNCT/79CXfcEgUIA3jc5GBfeXqoKsk3R8JZm2wRXJ2DiyjbPE4VMFOSDemLFcUTZmHEQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.4.tgz",
+      "integrity": "sha512-ARVxjAEX5TARFRzpDRVC6cEk0hUIXCCwaMhz8y7S1/PxU6zZS1UMjyobz7q4w/D/R552r4++EhwmXK1N2rAy0A==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -2254,6 +1790,12 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==",
+      "dev": true
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.18.tgz",
+      "integrity": "sha512-v/ZHEj9xh82usl8LMR3GarzFY1IrbXJw5L4QfQhokjRV91q+SelFqxQWSep1ucXEZ22+dSTwLFkXeur25sPIbw==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2451,6 +1993,317 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.3.1.tgz",
+      "integrity": "sha512-tUBEtWcF7wFtII7ayNiLNDTCE1X1afySEo+XNVMNkFXaThENyCowIEX095QqbJZGTgoOcSVDJGlnde2NG4jtbQ==",
+      "dev": true,
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.7.tgz",
+      "integrity": "sha512-pACdY6YnTNVLXsB86YD8OF9ihwpolzhhtdLVHhBL6do/ykr6kKXNYABRtNMGrsQXpEXXyAdwvWWkuTbs4MFtPQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.23.0",
+        "@vue/shared": "3.3.7",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.7.tgz",
+      "integrity": "sha512-0LwkyJjnUPssXv/d1vNJ0PKfBlDoQs7n81CbO6Q0zdL7H1EzqYRrTVXDqdBVqro0aJjo/FOa1qBAPVI4PGSHBw==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-core": "3.3.7",
+        "@vue/shared": "3.3.7"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.7.tgz",
+      "integrity": "sha512-7pfldWy/J75U/ZyYIXRVqvLRw3vmfxDo2YLMwVtWVNew8Sm8d6wodM+OYFq4ll/UxfqVr0XKiVwti32PCrruAw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.23.0",
+        "@vue/compiler-core": "3.3.7",
+        "@vue/compiler-dom": "3.3.7",
+        "@vue/compiler-ssr": "3.3.7",
+        "@vue/reactivity-transform": "3.3.7",
+        "@vue/shared": "3.3.7",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.5",
+        "postcss": "^8.4.31",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.7.tgz",
+      "integrity": "sha512-TxOfNVVeH3zgBc82kcUv+emNHo+vKnlRrkv8YvQU5+Y5LJGJwSNzcmLUoxD/dNzv0bhQ/F0s+InlgV0NrApJZg==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.3.7",
+        "@vue/shared": "3.3.7"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.1.tgz",
+      "integrity": "sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA==",
+      "dev": true
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.7.tgz",
+      "integrity": "sha512-cZNVjWiw00708WqT0zRpyAgduG79dScKEPYJXq2xj/aMtk3SKvL3FBt2QKUlh6EHBJ1m8RhBY+ikBUzwc7/khg==",
+      "dev": true,
+      "dependencies": {
+        "@vue/shared": "3.3.7"
+      }
+    },
+    "node_modules/@vue/reactivity-transform": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.7.tgz",
+      "integrity": "sha512-APhRmLVbgE1VPGtoLQoWBJEaQk4V8JUsqrQihImVqKT+8U6Qi3t5ATcg4Y9wGAPb3kIhetpufyZ1RhwbZCIdDA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.23.0",
+        "@vue/compiler-core": "3.3.7",
+        "@vue/shared": "3.3.7",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.5"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.7.tgz",
+      "integrity": "sha512-LHq9du3ubLZFdK/BP0Ysy3zhHqRfBn80Uc+T5Hz3maFJBGhci1MafccnL3rpd5/3wVfRHAe6c+PnlO2PAavPTQ==",
+      "dev": true,
+      "dependencies": {
+        "@vue/reactivity": "3.3.7",
+        "@vue/shared": "3.3.7"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.7.tgz",
+      "integrity": "sha512-PFQU1oeJxikdDmrfoNQay5nD4tcPNYixUBruZzVX/l0eyZvFKElZUjW4KctCcs52nnpMGO6UDK+jF5oV4GT5Lw==",
+      "dev": true,
+      "dependencies": {
+        "@vue/runtime-core": "3.3.7",
+        "@vue/shared": "3.3.7",
+        "csstype": "^3.1.2"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.7.tgz",
+      "integrity": "sha512-UlpKDInd1hIZiNuVVVvLgxpfnSouxKQOSE2bOfQpBuGwxRV/JqqTCyyjXUWiwtVMyeRaZhOYYqntxElk8FhBhw==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-ssr": "3.3.7",
+        "@vue/shared": "3.3.7"
+      },
+      "peerDependencies": {
+        "vue": "3.3.7"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.7.tgz",
+      "integrity": "sha512-N/tbkINRUDExgcPTBvxNkvHGu504k8lzlNQRITVnm6YjOjwa4r0nnbd4Jb01sNpur5hAllyRJzSK5PvB9PPwRg==",
+      "dev": true
+    },
+    "node_modules/@vueuse/core": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.5.0.tgz",
+      "integrity": "sha512-z/tI2eSvxwLRjOhDm0h/SXAjNm8N5ld6/SC/JQs6o6kpJ6Ya50LnEL8g5hoYu005i28L0zqB5L5yAl8Jl26K3A==",
+      "dev": true,
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.18",
+        "@vueuse/metadata": "10.5.0",
+        "@vueuse/shared": "10.5.0",
+        "vue-demi": ">=0.14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/core/node_modules/vue-demi": {
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+      "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.5.0.tgz",
+      "integrity": "sha512-fm5sXLCK0Ww3rRnzqnCQRmfjDURaI4xMsx+T+cec0ngQqHx/JgUtm8G0vRjwtonIeTBsH1Q8L3SucE+7K7upJQ==",
+      "dev": true,
+      "dependencies": {
+        "@vueuse/core": "10.5.0",
+        "@vueuse/shared": "10.5.0",
+        "vue-demi": ">=0.14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "*",
+        "axios": "*",
+        "change-case": "*",
+        "drauu": "*",
+        "focus-trap": "*",
+        "fuse.js": "*",
+        "idb-keyval": "*",
+        "jwt-decode": "*",
+        "nprogress": "*",
+        "qrcode": "*",
+        "sortablejs": "*",
+        "universal-cookie": "*"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/integrations/node_modules/vue-demi": {
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+      "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.5.0.tgz",
+      "integrity": "sha512-fEbElR+MaIYyCkeM0SzWkdoMtOpIwO72x8WsZHRE7IggiOlILttqttM69AS13nrDxosnDBYdyy3C5mR1LCxHsw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.5.0.tgz",
+      "integrity": "sha512-18iyxbbHYLst9MqU1X1QNdMHIjks6wC7XTVf0KNOv5es/Ms6gjVFCAAWTVP2JStuGqydg3DT+ExpFORUEi9yhg==",
+      "dev": true,
+      "dependencies": {
+        "vue-demi": ">=0.14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared/node_modules/vue-demi": {
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+      "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/acorn": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
@@ -2497,6 +2350,28 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/algoliasearch": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.20.0.tgz",
+      "integrity": "sha512-y+UHEjnOItoNy0bYO+WWmLWBlPwDjKHW6mNHrPi0NkuhpQOOEbrkwQH/wgKFDLh7qlKjzoKeiRtlpewDPDG23g==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/cache-browser-local-storage": "4.20.0",
+        "@algolia/cache-common": "4.20.0",
+        "@algolia/cache-in-memory": "4.20.0",
+        "@algolia/client-account": "4.20.0",
+        "@algolia/client-analytics": "4.20.0",
+        "@algolia/client-common": "4.20.0",
+        "@algolia/client-personalization": "4.20.0",
+        "@algolia/client-search": "4.20.0",
+        "@algolia/logger-common": "4.20.0",
+        "@algolia/logger-console": "4.20.0",
+        "@algolia/requester-browser-xhr": "4.20.0",
+        "@algolia/requester-common": "4.20.0",
+        "@algolia/requester-node-http": "4.20.0",
+        "@algolia/transporter": "4.20.0"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -2512,6 +2387,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
+      "dev": true
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -3028,6 +2909,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
+      "dev": true
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -3094,6 +2981,43 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -3241,6 +3165,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3364,6 +3294,15 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
+    },
+    "node_modules/focus-trap": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
+      "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
+      "dev": true,
+      "dependencies": {
+        "tabbable": "^6.2.0"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -3592,6 +3531,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3647,10 +3592,28 @@
         "node": ">=10"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
       "dev": true
     },
     "node_modules/merge2": {
@@ -3687,11 +3650,35 @@
         "node": "*"
       }
     },
+    "node_modules/minisearch": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.2.0.tgz",
+      "integrity": "sha512-BECkorDF1TY2rGKt9XHdSeP9TP29yUbrAaCh/C03wpyf1vx3uYcP/+8XlMcpTkgoU0rBVnHMAOaP83Rc9Tm+TQ==",
+      "dev": true
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -3803,6 +3790,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -3813,6 +3806,44 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.18.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.18.2.tgz",
+      "integrity": "sha512-X/K43vocUHDg0XhWVmTTMbec4LT/iBMh+csCEqJk+pJqegaXsvjdqN80ZZ3L+93azWCnWCZ+WGwYb8SplxeNjA==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/prelude-ls": {
@@ -3902,6 +3933,22 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "3.29.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
+      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3924,6 +3971,13 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/search-insights": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.9.0.tgz",
+      "integrity": "sha512-bkWW9nIHOFkLwjQ1xqVaMbjjO5vhP26ERsH9Y3pKr8imthofEFIxlnOabkmGcw6ksRj9jWidcI65vvjJH/nTGg==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.5.4",
@@ -3961,6 +4015,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.5.tgz",
+      "integrity": "sha512-1gCAYOcmCFONmErGTrS1fjzJLA7MGZmKzrBNX7apqSwhyITJg2O102uFzXUeBxNnEkDA9vHIKLyeKq0V083vIw==",
+      "dev": true,
+      "dependencies": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -3974,6 +4040,15 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4021,6 +4096,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "dev": true
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -4161,6 +4242,130 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
+    },
+    "node_modules/vite": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
+      "integrity": "sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.18.10",
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 14",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.24.tgz",
+      "integrity": "sha512-RpnL8cnOGwiRlBbrYQUm9sYkJbtyOt/wYXk2diTcokY4yvks/5lq9LuSt+MURWB6ZqwpSNHvTmxgaSfLoG0/OA==",
+      "dev": true,
+      "dependencies": {
+        "@docsearch/css": "^3.5.2",
+        "@docsearch/js": "^3.5.2",
+        "@types/markdown-it": "^13.0.4",
+        "@vitejs/plugin-vue": "4.3.1",
+        "@vue/devtools-api": "^6.5.1",
+        "@vueuse/core": "^10.5.0",
+        "@vueuse/integrations": "^10.5.0",
+        "focus-trap": "^7.5.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^6.1.0",
+        "shiki": "^0.14.5",
+        "vite": "^4.5.0",
+        "vue": "^3.3.6"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4.3.2",
+        "postcss": "^8.4.31"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
+    },
+    "node_modules/vue": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.7.tgz",
+      "integrity": "sha512-YEMDia1ZTv1TeBbnu6VybatmSteGOS3A3YgfINOfraCbf85wdKHzscD6HSS/vB4GAtI7sa1XPX7HcQaJ1l24zA==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.3.7",
+        "@vue/compiler-sfc": "3.3.7",
+        "@vue/runtime-dom": "3.3.7",
+        "@vue/server-renderer": "3.3.7",
+        "@vue/shared": "3.3.7"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "create": "node ./cli/magic.js create",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "format": "npx prettier --ignore-path .gitignore --write \"**/*.+(js|ts|jsx|tsx|json|css)\"",
-    "deploy": "npm run format && npx cdk deploy"
+    "deploy": "npm run format && npx cdk deploy",
+    "docs:dev": "vitepress dev docs",
+    "docs:build": "vitepress build docs",
+    "docs:preview": "vitepress preview docs"
   },
   "devDependencies": {
     "@aws-lambda-powertools/batch": "^1.14.1",
@@ -27,7 +30,8 @@
     "eslint": "^8.45.0",
     "prettier": "^3.0.3",
     "ts-node": "^10.9.1",
-    "typescript": "~5.1.3"
+    "typescript": "~5.1.3",
+    "vitepress": "^1.0.0-rc.24"
   },
   "dependencies": {
     "@aws-cdk/aws-apigatewayv2-alpha": "^2.104.0-alpha.0",


### PR DESCRIPTION
*Issue #, if available:*
#117 

*Description of changes:*
Create skeleton VitePress documentation website with a GitHub action to handle automatic build and deployment to GitHub pages on pushes to the main branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
