### PR TITLE
fix(shared_asset): correctly calculate hash to detect changes

### DIFF
--- a/lib/shared/index.ts
+++ b/lib/shared/index.ts
@@ -74,7 +74,6 @@ export class Shared extends Construct {
       // Create a VPC endpoint for S3.
       const s3GatewayEndpoint = vpc.addGatewayEndpoint("S3GatewayEndpoint", {
         service: ec2.GatewayVpcEndpointAwsService.S3,
-        
       });
 
       const s3vpcEndpoint = vpc.addInterfaceEndpoint("S3InterfaceEndpoint", {
@@ -101,7 +100,6 @@ export class Shared extends Construct {
         service: ec2.InterfaceVpcEndpointAwsService.SAGEMAKER_RUNTIME,
         open: true,
       });
-
     }
 
     const configParameter = new ssm.StringParameter(this, "Config", {
@@ -125,9 +123,9 @@ export class Shared extends Construct {
       path: path.join(__dirname, "./layers/common"),
     });
 
-    this.sharedCode = new SharedAssetBundler(this, 'genai-core', [ 
-      path.join(__dirname, 'layers', 'python-sdk', 'python', 'genai_core')
-    ])
+    this.sharedCode = new SharedAssetBundler(this, "genai-core", [
+      path.join(__dirname, "layers", "python-sdk", "python", "genai_core"),
+    ]);
 
     const xOriginVerifySecret = new secretsmanager.Secret(
       this,

--- a/lib/shared/shared-asset-bundler.ts
+++ b/lib/shared/shared-asset-bundler.ts
@@ -1,4 +1,9 @@
-import { AssetHashType, BundlingOutput, DockerImage, aws_s3_assets } from "aws-cdk-lib";
+import {
+  AssetHashType,
+  BundlingOutput,
+  DockerImage,
+  aws_s3_assets,
+} from "aws-cdk-lib";
 import { Code, S3Code } from "aws-cdk-lib/aws-lambda";
 import { Asset } from "aws-cdk-lib/aws-s3-assets";
 import { md5hash } from "aws-cdk-lib/core/lib/helpers-internal";
@@ -7,55 +12,69 @@ import * as path from "path";
 import * as fs from "fs";
 
 function calculateHash(paths: string[]): string {
-    return paths.reduce((mh, p) => {
-        const dirs = fs.readdirSync(p);
-        let hash = calculateHash(dirs.filter(d => fs.statSync(path.join(p, d)).isDirectory()).map(v => path.join(p, v)))
-        return md5hash(mh + dirs.filter(d => fs.statSync(path.join(p,d)).isFile()).reduce((h, f) => { return md5hash(h + fs.readFileSync(path.join(p,f)))}, hash));
-        }, ""
-    )
+  return paths.reduce((mh, p) => {
+    const dirs = fs.readdirSync(p);
+    let hash = calculateHash(
+      dirs
+        .filter((d) => fs.statSync(path.join(p, d)).isDirectory())
+        .map((v) => path.join(p, v))
+    );
+    return md5hash(
+      mh +
+        dirs
+          .filter((d) => fs.statSync(path.join(p, d)).isFile())
+          .reduce((h, f) => {
+            return md5hash(h + fs.readFileSync(path.join(p, f)));
+          }, hash)
+    );
+  }, "");
 }
 
 export class SharedAssetBundler extends Construct {
-    private readonly sharedAssets: string[];
-    private readonly WORKING_PATH = '/asset-input/'
-    /**
-     * Instantiate a new SharedAssetBundler. You then invoke `bundleWithAsset(pathToAsset)` to 
-     * bundle your asset code with the common code.
-     * 
-     * For Lambda function handler assets, you can use `bundleWithLambdaAsset(pathToAsset)` as 
-     * a drop-in replacement for `lambda.Code.fromAsset()`
-     * 
-     * @param scope 
-     * @param id 
-     * @param commonFolders : array of common folders to bundle with your asset code
-     */
-    constructor(scope: Construct, id: string, sharedAssets: string[]) {
-        super(scope, id);
-        this.sharedAssets = sharedAssets;
-    }
+  private readonly sharedAssets: string[];
+  private readonly WORKING_PATH = "/asset-input/";
+  /**
+   * Instantiate a new SharedAssetBundler. You then invoke `bundleWithAsset(pathToAsset)` to
+   * bundle your asset code with the common code.
+   *
+   * For Lambda function handler assets, you can use `bundleWithLambdaAsset(pathToAsset)` as
+   * a drop-in replacement for `lambda.Code.fromAsset()`
+   *
+   * @param scope
+   * @param id
+   * @param commonFolders : array of common folders to bundle with your asset code
+   */
+  constructor(scope: Construct, id: string, sharedAssets: string[]) {
+    super(scope, id);
+    this.sharedAssets = sharedAssets;
+  }
 
-    bundleWithAsset(assetPath: string): Asset {
-        console.log(`Bundling asset ${assetPath}`)
-        const asset = new aws_s3_assets.Asset(this, md5hash(assetPath).slice(0, 6), {
-            path: assetPath,
-            bundling: {
-                image: DockerImage.fromBuild(path.join(__dirname, 'alpine-zip')),
-                command: ["zip", "-r", path.join("/asset-output", "asset.zip"), "."],
-                volumes: this.sharedAssets.map(f => ({
-                        containerPath: path.join(this.WORKING_PATH, path.basename(f)),
-                        hostPath: f
-                    })),
-                workingDirectory: this.WORKING_PATH,
-                outputType: BundlingOutput.ARCHIVED,
-            },
-            assetHash: calculateHash([assetPath, ...this.sharedAssets]),
-            assetHashType: AssetHashType.CUSTOM,
-        })
-        return asset;
-    }
+  bundleWithAsset(assetPath: string): Asset {
+    console.log(`Bundling asset ${assetPath}`);
+    const asset = new aws_s3_assets.Asset(
+      this,
+      md5hash(assetPath).slice(0, 6),
+      {
+        path: assetPath,
+        bundling: {
+          image: DockerImage.fromBuild(path.join(__dirname, "alpine-zip")),
+          command: ["zip", "-r", path.join("/asset-output", "asset.zip"), "."],
+          volumes: this.sharedAssets.map((f) => ({
+            containerPath: path.join(this.WORKING_PATH, path.basename(f)),
+            hostPath: f,
+          })),
+          workingDirectory: this.WORKING_PATH,
+          outputType: BundlingOutput.ARCHIVED,
+        },
+        assetHash: calculateHash([assetPath, ...this.sharedAssets]),
+        assetHashType: AssetHashType.CUSTOM,
+      }
+    );
+    return asset;
+  }
 
-    bundleWithLambdaAsset(assetPath: string): S3Code {
-        const asset = this.bundleWithAsset(assetPath);
-        return Code.fromBucket(asset.bucket, asset.s3ObjectKey);
-    }
+  bundleWithLambdaAsset(assetPath: string): S3Code {
+    const asset = this.bundleWithAsset(assetPath);
+    return Code.fromBucket(asset.bucket, asset.s3ObjectKey);
+  }
 }

--- a/lib/shared/shared-asset-bundler.ts
+++ b/lib/shared/shared-asset-bundler.ts
@@ -10,7 +10,7 @@ function calculateHash(paths: string[]): string {
     return paths.reduce((mh, p) => {
         const dirs = fs.readdirSync(p);
         let hash = calculateHash(dirs.filter(d => fs.statSync(path.join(p, d)).isDirectory()).map(v => path.join(p, v)))
-        return md5hash(mh + dirs.filter(d => !fs.statSync(path.join(p,d)).isDirectory()).reduce((h, f) => { return md5hash(h + fs.readFileSync(path.join(p,f)))}, hash));
+        return md5hash(mh + dirs.filter(d => fs.statSync(path.join(p,d)).isFile()).reduce((h, f) => { return md5hash(h + fs.readFileSync(path.join(p,f)))}, hash));
         }, ""
     )
 }


### PR DESCRIPTION
*Issue #, if available:*

fix #216

*Description of changes:*
Introduced a custom hash function to calculate the md5 hash of all source files that make up the asset.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
