### PR TITLE
fix(create_tool): better hints on multiselect

### DIFF
--- a/cli/magic-create.ts
+++ b/cli/magic-create.ts
@@ -156,8 +156,8 @@ async function processCreateOptions(options: any): Promise<void> {
     {
       type: "multiselect",
       name: "sagemakerModels",
-      message:
-        "Which SageMaker Models do you want to enable (enter for None, space to select)",
+      hint: "SPACE to select, ENTER to confirm selection",
+      message: "Which SageMaker Models do you want to enable",
       choices: Object.values(SupportedSageMakerModels),
       initial:
         (options.sagemakerModels ?? []).filter((m: string) =>
@@ -175,8 +175,8 @@ async function processCreateOptions(options: any): Promise<void> {
     {
       type: "multiselect",
       name: "ragsToEnable",
-      message:
-        "Which datastores do you want to enable for RAG (enter for None, space to select)",
+      hint: "SPACE to select, ENTER to confirm selection",
+      message: "Which datastores do you want to enable for RAG",
       choices: [
         { message: "Aurora", name: "aurora" },
         { message: "OpenSearch", name: "opensearch" },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is an effort to improve the user experience by providing clearer and emphasized instructions on how to use the multiselect option in the configuration creation tool.

![image](https://github.com/aws-samples/aws-genai-llm-chatbot/assets/38036163/973ccbcb-76c5-4b92-8993-578249471fa0)

NOTE: blue highlight is just to show the difference

![image](https://github.com/aws-samples/aws-genai-llm-chatbot/assets/38036163/f1e08c33-c4bc-48a3-a1e0-059d716a4879)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
