### PR TITLE
fix(powertools): set dev env var to false for compact logging

### DIFF
--- a/lib/shared/index.ts
+++ b/lib/shared/index.ts
@@ -35,7 +35,7 @@ export class Shared extends Construct {
     const powerToolsLayerVersion = "46";
 
     this.defaultEnvironmentVariables = {
-      POWERTOOLS_DEV: "true",
+      POWERTOOLS_DEV: "false",
       LOG_LEVEL: "INFO",
       POWERTOOLS_LOGGER_LOG_EVENT: "true",
       POWERTOOLS_SERVICE_NAME: "chatbot",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Setting POWERTOOLS_DEV variable default to "false" to get more compact logging

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
