### PR TITLE
fix(wizard): validate is run even when entry is skipped

### DIFF
--- a/cli/magic-create.ts
+++ b/cli/magic-create.ts
@@ -164,7 +164,7 @@ async function processCreateOptions(options: any): Promise<void> {
             .includes(m)
         ) || [],
       validate(choices: any) {
-        return choices.length > 0
+        return (this as any).skipped || choices.length > 0
           ? true
           : "You need to select at least one model";
       },
@@ -204,12 +204,13 @@ async function processCreateOptions(options: any): Promise<void> {
         (options.kendraExternal !== undefined &&
           options.kendraExternal.length > 0) ||
         false,
-      skip: function (): boolean {
+      skip(): boolean {
         return !(this as any).state.answers.enableRag;
       },
     },
   ];
   const answers: any = await enquirer.prompt(questions);
+  console.log(answers);
   const kendraExternal = [];
   let newKendra = answers.enableRag && answers.kendra;
   const existingKendraIndices = Array.from(options.kendraExternal || []);


### PR DESCRIPTION
*Issue #, if available:*

fix #242 

*Description of changes:*

the `validate()` action is run also when the entry should be skipped and returned `false`. Apparently this causes `enquirer` to silently exit. 

Fixed the `validate()` function to return `true` in case the entry is skipped. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
