### PR TITLE
Toggle SageMaker Endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -445,3 +445,6 @@ bin/config.json
 # Docs
 docs/.vitepress/cache
 docs/.vitepress/dist
+
+# Folder for misc assets during development
+.dev-assets/

--- a/lib/chatbot-api/index.ts
+++ b/lib/chatbot-api/index.ts
@@ -4,7 +4,7 @@ import * as cognito from "aws-cdk-lib/aws-cognito";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import * as sns from "aws-cdk-lib/aws-sns";
-import * as ssm from "aws-cdk-lib/aws-ssm";
+import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import { RagEngines } from "../rag-engines";
 import { Shared } from "../shared";
@@ -19,12 +19,11 @@ export interface ChatBotApiProps {
   readonly config: SystemConfig;
   readonly ragEngines?: RagEngines;
   readonly userPool: cognito.UserPool;
-  readonly modelsParameter: ssm.StringParameter;
-  readonly models: SageMakerModelEndpoint[];
 }
 
 export class ChatBotApi extends Construct {
   public readonly restApi: apigateway.RestApi;
+  public readonly apiHandler: lambda.Function;
   public readonly webSocketApi: apigwv2.WebSocketApi;
   public readonly messagesTopic: sns.Topic;
   public readonly sessionsTable: dynamodb.Table;
@@ -46,6 +45,7 @@ export class ChatBotApi extends Construct {
     const webSocketApi = new WebSocketApi(this, "WebSocketApi", props);
 
     this.restApi = restApi.api;
+    this.apiHandler = restApi.apiHandler;
     this.webSocketApi = webSocketApi.api;
     this.messagesTopic = webSocketApi.messagesTopic;
     this.sessionsTable = chatTables.sessionsTable;

--- a/lib/chatbot-api/rest-api.ts
+++ b/lib/chatbot-api/rest-api.ts
@@ -1,8 +1,6 @@
 import * as path from "path";
 import * as cdk from "aws-cdk-lib";
 import {
-  MODEL_PARAMETER_PATH,
-  SageMakerModelEndpoint,
   SystemConfig,
 } from "../shared/types";
 import { Construct } from "constructs";
@@ -55,7 +53,7 @@ export class RestApi extends Construct {
       environment: {
         ...props.shared.defaultEnvironmentVariables,
         CONFIG_PARAMETER_NAME: props.shared.configParameter.parameterName,
-        MODELS_PARAMETER_NAME: `/${MODEL_PARAMETER_PATH}/`,
+        MODELS_PARAMETER_NAME: `/${props.config.prefix}GenAIChatBotStack/`,
         X_ORIGIN_VERIFY_SECRET_ARN: props.shared.xOriginVerifySecret.secretArn,
         API_KEYS_SECRETS_ARN: props.shared.apiKeysSecret.secretArn,
         SESSIONS_TABLE_NAME: props.sessionsTable.tableName,
@@ -252,7 +250,7 @@ export class RestApi extends Construct {
         ],
         effect: iam.Effect.ALLOW,
         resources: [
-          `arn:${cdk.Aws.PARTITION}:ssm:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:parameter/${MODEL_PARAMETER_PATH}/*`,
+          `arn:${cdk.Aws.PARTITION}:ssm:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:parameter/${props.config.prefix}GenAIChatBotStack/*`,
         ],
       })
     );

--- a/lib/models/index.ts
+++ b/lib/models/index.ts
@@ -1,106 +1,148 @@
 import * as cdk from "aws-cdk-lib";
-import * as ssm from "aws-cdk-lib/aws-ssm";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as servicecatalog from "aws-cdk-lib/aws-servicecatalog";
 import { Construct } from "constructs";
 import {
   ContainerImages,
   DeploymentType,
   SageMakerModel,
+  SageMakerModelProduct,
 } from "../sagemaker-model";
 import { Shared } from "../shared";
 import {
   Modality,
   ModelInterface,
-  SageMakerModelEndpoint,
-  SupportedSageMakerModels,
   SystemConfig,
 } from "../shared/types";
+import { RagEngines } from "../rag-engines";
+import { ChatBotApi } from "../chatbot-api";
 
 export interface ModelsProps {
   readonly config: SystemConfig;
   readonly shared: Shared;
+  readonly ragEngines?: RagEngines;
+  readonly chatBotApi: ChatBotApi;
 }
 
 export class Models extends Construct {
-  public readonly models: SageMakerModelEndpoint[];
-  public readonly modelsParameter: ssm.StringParameter;
+  public readonly modelsParameterPath: string = "/chatbot/models/";
+  public readonly portfolio: servicecatalog.Portfolio;
 
   constructor(scope: Construct, id: string, props: ModelsProps) {
     super(scope, id);
+    const portfolioAssetBucket = new s3.Bucket(this, "PortfolioAssetBucket");
 
-    const models: SageMakerModelEndpoint[] = [];
+    const portfolio = new servicecatalog.Portfolio(this, "ModelsPortfolio", {
+      displayName: "GenAI Chatbot SageMaker Models",
+      providerName: "GenAI Chatbot",
+      description:
+        "Models that can be launched to be used with the GenAI Chatbot",
+    });
 
-    if (
-      props.config.llms?.sagemaker.includes(SupportedSageMakerModels.FalconLite)
-    ) {
-      const falconLite = new SageMakerModel(this, "FalconLite", {
-        vpc: props.shared.vpc,
-        region: cdk.Aws.REGION,
-        model: {
-          type: DeploymentType.Container,
-          modelId: "amazon/FalconLite",
-          container: ContainerImages.HF_PYTORCH_LLM_TGI_INFERENCE_0_9_3,
-          instanceType: "ml.g5.12xlarge",
-          // https://github.com/awslabs/extending-the-context-length-of-open-source-llms/blob/main/custom-tgi-ecr/deploy.ipynb
-          containerStartupHealthCheckTimeoutInSeconds: 600,
-          env: {
-            SM_NUM_GPUS: JSON.stringify(4),
-            MAX_INPUT_LENGTH: JSON.stringify(12000),
-            MAX_TOTAL_TOKENS: JSON.stringify(12001),
-            HF_MODEL_QUANTIZE: "gptq",
-            TRUST_REMOTE_CODE: JSON.stringify(true),
-            MAX_BATCH_PREFILL_TOKENS: JSON.stringify(12001),
-            MAX_BATCH_TOTAL_TOKENS: JSON.stringify(12001),
-            GPTQ_BITS: JSON.stringify(4),
-            GPTQ_GROUPSIZE: JSON.stringify(128),
-            DNTK_ALPHA_SCALER: JSON.stringify(0.25),
-          },
-        },
-      });
-
-      models.push({
-        name: falconLite.endpoint.endpointName!,
-        endpoint: falconLite.endpoint,
-        responseStreamingSupported: false,
-        inputModalities: [Modality.Text],
-        outputModalities: [Modality.Text],
-        interface: ModelInterface.LangChain,
-        ragSupported: true,
-      });
+    if (props.chatBotApi.apiHandler.role) {
+      portfolio.giveAccessToRole(props.chatBotApi.apiHandler.role);
     }
 
-    if (
-      props.config.llms?.sagemaker.includes(
-        SupportedSageMakerModels.Mistral7b_Instruct
-      )
-    ) {
-      const mistral7bInstruct = new SageMakerModel(this, "Mistral7BInstruct", {
-        vpc: props.shared.vpc,
-        region: cdk.Aws.REGION,
-        model: {
-          type: DeploymentType.Container,
-          modelId: "mistralai/Mistral-7B-Instruct-v0.1",
-          container: ContainerImages.HF_PYTORCH_LLM_TGI_INFERENCE_1_1_0,
-          instanceType: "ml.g5.2xlarge",
-          containerStartupHealthCheckTimeoutInSeconds: 300,
-          env: {
-            SM_NUM_GPUS: JSON.stringify(1),
-            MAX_INPUT_LENGTH: JSON.stringify(2048),
-            MAX_TOTAL_TOKENS: JSON.stringify(4096),
-            //HF_MODEL_QUANTIZE: "bitsandbytes",
-          },
-        },
-      });
+    const defaultSecurityGroup = props.shared.vpc.vpcDefaultSecurityGroup;
 
-      models.push({
-        name: mistral7bInstruct.endpoint.endpointName!,
-        endpoint: mistral7bInstruct.endpoint,
-        responseStreamingSupported: false,
-        inputModalities: [Modality.Text],
-        outputModalities: [Modality.Text],
-        interface: ModelInterface.LangChain,
-        ragSupported: true,
-      });
-    }
+
+    const falconLiteProduct = new servicecatalog.CloudFormationProduct(
+      this,
+      "FalconLiteProduct",
+      {
+        owner: "GenAI Chatbot",
+        productName: "FalconLite",
+        productVersions: [
+          {
+            cloudFormationTemplate:
+              servicecatalog.CloudFormationTemplate.fromProductStack(
+                new SageMakerModelProduct(this, "FalconLite", {
+                  assetBucket: portfolioAssetBucket,
+                  vpc: props.shared.vpc,
+                  securityGroupId: defaultSecurityGroup,
+                  region: cdk.Aws.REGION,
+                  model: {
+                    type: DeploymentType.Container,
+                    modelId: "amazon/FalconLite",
+                    container: ContainerImages.HF_PYTORCH_LLM_TGI_INFERENCE_0_9_3,
+                    instanceType: "ml.g5.12xlarge",
+                    // https://github.com/awslabs/extending-the-context-length-of-open-source-llms/blob/main/custom-tgi-ecr/deploy.ipynb
+                    containerStartupHealthCheckTimeoutInSeconds: 600,
+                    env: {
+                      SM_NUM_GPUS: JSON.stringify(4),
+                      MAX_INPUT_LENGTH: JSON.stringify(12000),
+                      MAX_TOTAL_TOKENS: JSON.stringify(12001),
+                      HF_MODEL_QUANTIZE: "gptq",
+                      TRUST_REMOTE_CODE: JSON.stringify(true),
+                      MAX_BATCH_PREFILL_TOKENS: JSON.stringify(12001),
+                      MAX_BATCH_TOTAL_TOKENS: JSON.stringify(12001),
+                      GPTQ_BITS: JSON.stringify(4),
+                      GPTQ_GROUPSIZE: JSON.stringify(128),
+                      DNTK_ALPHA_SCALER: JSON.stringify(0.25),
+                    },
+                  },
+                  responseStreamingSupported: false,
+                  inputModalities: [Modality.Text],
+                  outputModalities: [Modality.Text],
+                  interface: ModelInterface.LangChain,
+                  ragSupported: true,
+                  apiHandler: props.chatBotApi.apiHandler,
+                })
+              ),
+          },
+        ],
+      }
+    );
+
+    portfolio.addProduct(falconLiteProduct);
+
+
+
+    const mistral7bInstructProduct = new servicecatalog.CloudFormationProduct(
+      this,
+      "Mistral7bInstructProduct",
+      {
+        owner: "GenAI Chatbot",
+        productName: "Mistral7BInstruct",
+        productVersions: [
+          {
+            cloudFormationTemplate:
+              servicecatalog.CloudFormationTemplate.fromProductStack(
+                new SageMakerModelProduct(
+                  this,
+                  "Mistral7BInstruct",
+                  {
+                    vpc: props.shared.vpc,
+                    securityGroupId: defaultSecurityGroup,
+                    region: cdk.Aws.REGION,
+                    model: {
+                      type: DeploymentType.Container,
+                      modelId: "mistralai/Mistral-7B-Instruct-v0.1",
+                      container: ContainerImages.HF_PYTORCH_LLM_TGI_INFERENCE_1_1_0,
+                      instanceType: "ml.g5.2xlarge",
+                      containerStartupHealthCheckTimeoutInSeconds: 300,
+                      env: {
+                        SM_NUM_GPUS: JSON.stringify(1),
+                        MAX_INPUT_LENGTH: JSON.stringify(2048),
+                        MAX_TOTAL_TOKENS: JSON.stringify(4096),
+                        //HF_MODEL_QUANTIZE: "bitsandbytes",
+                      },
+                    },
+                    responseStreamingSupported: false,
+                    inputModalities: [Modality.Text],
+                    outputModalities: [Modality.Text],
+                    interface: ModelInterface.LangChain,
+                    ragSupported: true,
+                    apiHandler: props.chatBotApi.apiHandler,
+                  }
+                )
+              ),
+          },
+        ],
+      }
+    );
+
+    portfolio.addProduct(mistral7bInstructProduct);
 
     // To get Jumpstart model ARNs do the following
     // 1. Identify the modelId via https://sagemaker.readthedocs.io/en/stable/doc_utils/pretrainedmodels.html
@@ -111,140 +153,159 @@ export class Models extends Construct {
     //      model_id = 'meta-textgeneration-llama-2-13b-f'
     //      model = JumpStartModel(model_id=model_id, region=region)
     //      print(model.model_package_arn)
-    if (
-      props.config.llms?.sagemaker.includes(
-        SupportedSageMakerModels.Llama2_13b_Chat
-      )
-    ) {
-      const llama2chat = new SageMakerModel(this, "LLamaV2_13B_Chat", {
-        vpc: props.shared.vpc,
-        region: cdk.Aws.REGION,
-        model: {
-          type: DeploymentType.ModelPackage,
-          modelId: "meta-LLama2-13b-chat",
-          instanceType: "ml.g5.12xlarge",
-          packages: (scope) =>
-            new cdk.CfnMapping(scope, "Llama2ChatPackageMapping", {
-              lazy: true,
-              mapping: {
-                "ap-southeast-1": {
-                  arn: `arn:aws:sagemaker:ap-southeast-1:192199979996:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
-                },
-                "ap-southeast-2": {
-                  arn: `arn:aws:sagemaker:ap-southeast-2:666831318237:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
-                },
-                "eu-west-1": {
-                  arn: `arn:aws:sagemaker:eu-west-1:985815980388:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
-                },
-                "us-east-1": {
-                  arn: `arn:aws:sagemaker:us-east-1:865070037744:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
-                },
-                "us-east-2": {
-                  arn: `arn:aws:sagemaker:us-east-2:057799348421:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
-                },
-                "us-west-2": {
-                  arn: `arn:aws:sagemaker:us-west-2:594846645681:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
-                },
-              },
-            }),
-        },
-      });
 
-      models.push({
-        name: "meta-LLama2-13b-chat",
-        endpoint: llama2chat.endpoint,
-        responseStreamingSupported: false,
-        inputModalities: [Modality.Text],
-        outputModalities: [Modality.Text],
-        interface: ModelInterface.LangChain,
-        ragSupported: true,
-      });
-    }
 
-    if (
-      props.config.llms?.sagemaker.includes(SupportedSageMakerModels.Idefics_9b)
-    ) {
-      const idefics9b = new SageMakerModel(this, "IDEFICS9B", {
-        vpc: props.shared.vpc,
-        region: cdk.Aws.REGION,
-        model: {
-          type: DeploymentType.Container,
-          modelId: "HuggingFaceM4/idefics-9b-instruct",
-          container: ContainerImages.HF_PYTORCH_LLM_TGI_INFERENCE_1_1_0,
-          instanceType: "ml.g5.12xlarge",
-          containerStartupHealthCheckTimeoutInSeconds: 300,
-          env: {
-            SM_NUM_GPUS: JSON.stringify(4),
-            MAX_INPUT_LENGTH: JSON.stringify(1024),
-            MAX_TOTAL_TOKENS: JSON.stringify(2048),
-            MAX_BATCH_TOTAL_TOKENS: JSON.stringify(8192),
+
+    const llama2chatProduct = new servicecatalog.CloudFormationProduct(
+      this,
+      "LLamaV2_13B_ChatProduct",
+      {
+        owner: "GenAI Chatbot",
+        productName: "LLamaV2_13B_Chat",
+        productVersions: [
+          {
+            cloudFormationTemplate:
+              servicecatalog.CloudFormationTemplate.fromProductStack(
+                new SageMakerModelProduct(this, "LLamaV2_13B_Chat", {
+                  assetBucket: portfolioAssetBucket,
+                  vpc: props.shared.vpc,
+                  securityGroupId: defaultSecurityGroup,
+                  region: cdk.Aws.REGION,
+                  model: {
+                    type: DeploymentType.ModelPackage,
+                    modelId: "meta-LLama2-13b-chat",
+                    instanceType: "ml.g5.12xlarge",
+                    packages: (scope) =>
+                      new cdk.CfnMapping(scope, "Llama2ChatPackageMapping", {
+                        lazy: true,
+                        mapping: {
+                          "ap-southeast-1": {
+                            arn: `arn:aws:sagemaker:ap-southeast-1:192199979996:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
+                          },
+                          "ap-southeast-2": {
+                            arn: `arn:aws:sagemaker:ap-southeast-2:666831318237:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
+                          },
+                          "eu-west-1": {
+                            arn: `arn:aws:sagemaker:eu-west-1:985815980388:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
+                          },
+                          "us-east-1": {
+                            arn: `arn:aws:sagemaker:us-east-1:865070037744:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
+                          },
+                          "us-east-2": {
+                            arn: `arn:aws:sagemaker:us-east-2:057799348421:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
+                          },
+                          "us-west-2": {
+                            arn: `arn:aws:sagemaker:us-west-2:594846645681:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
+                          },
+                        },
+                      }),
+                  },
+                  responseStreamingSupported: false,
+                  inputModalities: [Modality.Text],
+                  outputModalities: [Modality.Text],
+                  interface: ModelInterface.LangChain,
+                  ragSupported: true,
+                  apiHandler: props.chatBotApi.apiHandler,
+                })
+              ),
           },
-        },
-      });
+        ],
+      }
+    );
 
-      models.push({
-        name: idefics9b.endpoint.endpointName!,
-        endpoint: idefics9b.endpoint,
-        responseStreamingSupported: false,
-        inputModalities: [Modality.Text, Modality.Image],
-        outputModalities: [Modality.Text],
-        interface: ModelInterface.Idefics,
-        ragSupported: false,
-      });
-    }
+    portfolio.addProduct(llama2chatProduct);
 
-    if (
-      props.config.llms?.sagemaker.includes(
-        SupportedSageMakerModels.Idefics_80b
-      )
-    ) {
-      const idefics80b = new SageMakerModel(this, "IDEFICS80B", {
-        vpc: props.shared.vpc,
-        region: cdk.Aws.REGION,
-        model: {
-          type: DeploymentType.Container,
-          modelId: "HuggingFaceM4/idefics-80b-instruct",
-          container: ContainerImages.HF_PYTORCH_LLM_TGI_INFERENCE_1_1_0,
-          instanceType: "ml.g5.48xlarge",
-          containerStartupHealthCheckTimeoutInSeconds: 600,
-          env: {
-            SM_NUM_GPUS: JSON.stringify(8),
-            MAX_INPUT_LENGTH: JSON.stringify(1024),
-            MAX_TOTAL_TOKENS: JSON.stringify(2048),
-            MAX_BATCH_TOTAL_TOKENS: JSON.stringify(8192),
-            // quantization required to work with ml.g5.48xlarge
-            // comment if deploying with ml.p4d or ml.p4e instances
-            HF_MODEL_QUANTIZE: "bitsandbytes",
+
+
+    const idefics9bProduct = new servicecatalog.CloudFormationProduct(
+      this,
+      "IDEFICS9BProduct",
+      {
+        owner: "GenAI Chatbot",
+        productName: "IDEFICS9B",
+        productVersions: [
+          {
+            cloudFormationTemplate:
+              servicecatalog.CloudFormationTemplate.fromProductStack(new SageMakerModelProduct(this, "IDEFICS9B", {
+                assetBucket: portfolioAssetBucket,
+                vpc: props.shared.vpc,
+                securityGroupId: defaultSecurityGroup,
+                region: cdk.Aws.REGION,
+                model: {
+                  type: DeploymentType.Container,
+                  modelId: "HuggingFaceM4/idefics-9b-instruct",
+                  container: ContainerImages.HF_PYTORCH_LLM_TGI_INFERENCE_1_1_0,
+                  instanceType: "ml.g5.12xlarge",
+                  containerStartupHealthCheckTimeoutInSeconds: 300,
+                  env: {
+                    SM_NUM_GPUS: JSON.stringify(4),
+                    MAX_INPUT_LENGTH: JSON.stringify(1024),
+                    MAX_TOTAL_TOKENS: JSON.stringify(2048),
+                    MAX_BATCH_TOTAL_TOKENS: JSON.stringify(8192),
+                  },
+                },
+                responseStreamingSupported: false,
+                inputModalities: [Modality.Text, Modality.Image],
+                outputModalities: [Modality.Text],
+                interface: ModelInterface.Idefics,
+                ragSupported: false,
+                apiHandler: props.chatBotApi.apiHandler,
+              })),
           },
-        },
-      });
+        ],
+      }
+    );
 
-      models.push({
-        name: idefics80b.endpoint.endpointName!,
-        endpoint: idefics80b.endpoint,
-        responseStreamingSupported: false,
-        inputModalities: [Modality.Text, Modality.Image],
-        outputModalities: [Modality.Text],
-        interface: ModelInterface.Idefics,
-        ragSupported: false,
-      });
-    }
+    portfolio.addProduct(idefics9bProduct);
 
-    const modelsParameter = new ssm.StringParameter(this, "ModelsParameter", {
-      stringValue: JSON.stringify(
-        models.map((model) => ({
-          name: model.name,
-          endpoint: model.endpoint.endpointName,
-          responseStreamingSupported: model.responseStreamingSupported,
-          inputModalities: model.inputModalities,
-          outputModalities: model.outputModalities,
-          interface: model.interface,
-          ragSupported: model.ragSupported,
-        }))
-      ),
-    });
 
-    this.models = models;
-    this.modelsParameter = modelsParameter;
+
+    const idefics80bProduct = new servicecatalog.CloudFormationProduct(
+      this,
+      "IDEFICS80BProduct",
+      {
+        owner: "GenAI Chatbot",
+        productName: "IDEFICS80B",
+        productVersions: [
+          {
+            cloudFormationTemplate:
+              servicecatalog.CloudFormationTemplate.fromProductStack(
+                new SageMakerModelProduct(this, "IDEFICS80B", {
+                  assetBucket: portfolioAssetBucket,
+                  vpc: props.shared.vpc,
+                  securityGroupId: defaultSecurityGroup,
+                  region: cdk.Aws.REGION,
+                  model: {
+                    type: DeploymentType.Container,
+                    modelId: "HuggingFaceM4/idefics-80b-instruct",
+                    container: ContainerImages.HF_PYTORCH_LLM_TGI_INFERENCE_1_1_0,
+                    instanceType: "ml.g5.48xlarge",
+                    containerStartupHealthCheckTimeoutInSeconds: 600,
+                    env: {
+                      SM_NUM_GPUS: JSON.stringify(8),
+                      MAX_INPUT_LENGTH: JSON.stringify(1024),
+                      MAX_TOTAL_TOKENS: JSON.stringify(2048),
+                      MAX_BATCH_TOTAL_TOKENS: JSON.stringify(8192),
+                      // quantization required to work with ml.g5.48xlarge
+                      // comment if deploying with ml.p4d or ml.p4e instances
+                      HF_MODEL_QUANTIZE: "bitsandbytes",
+                    },
+                  },
+                  responseStreamingSupported: false,
+                  inputModalities: [Modality.Text, Modality.Image],
+                  outputModalities: [Modality.Text],
+                  interface: ModelInterface.Idefics,
+                  ragSupported: false,
+                  apiHandler: props.chatBotApi.apiHandler,
+                })
+              ),
+          },
+        ],
+      }
+    );
+
+    portfolio.addProduct(idefics80bProduct);
+
+    this.portfolio = portfolio;
   }
 }

--- a/lib/models/index.ts
+++ b/lib/models/index.ts
@@ -1,8 +1,8 @@
 import * as cdk from "aws-cdk-lib";
 import * as s3 from "aws-cdk-lib/aws-s3";
-import * as ssm from "aws-cdk-lib/aws-ssm"
+import * as ssm from "aws-cdk-lib/aws-ssm";
 import * as servicecatalog from "aws-cdk-lib/aws-servicecatalog";
-import * as iam from "aws-cdk-lib/aws-iam"
+import * as iam from "aws-cdk-lib/aws-iam";
 import { Construct } from "constructs";
 import {
   ContainerImages,
@@ -10,11 +10,7 @@ import {
   SageMakerModelProduct,
 } from "../sagemaker-model";
 import { Shared } from "../shared";
-import {
-  Modality,
-  ModelInterface,
-  SystemConfig,
-} from "../shared/types";
+import { Modality, ModelInterface, SystemConfig } from "../shared/types";
 import { RagEngines } from "../rag-engines";
 import { ChatBotApi } from "../chatbot-api";
 
@@ -31,9 +27,9 @@ export class Models extends Construct {
   constructor(scope: Construct, id: string, props: ModelsProps) {
     super(scope, id);
     const portfolioAssetBucket = new s3.Bucket(this, "PortfolioAssetBucket");
-    const productOwner = `${props.config.prefix}GenAIChatBotStack`
+    const productOwner = `${props.config.prefix}GenAIChatBotStack`;
     const defaultSecurityGroup = props.shared.vpc.vpcDefaultSecurityGroup;
-    const falconLiteModelId = "amazon/FalconLite"
+    const falconLiteModelId = "amazon/FalconLite";
     const falconLiteProduct = new servicecatalog.CloudFormationProduct(
       scope,
       "FalconLiteProduct",
@@ -52,7 +48,8 @@ export class Models extends Construct {
                   model: {
                     type: DeploymentType.Container,
                     modelId: falconLiteModelId,
-                    container: ContainerImages.HF_PYTORCH_LLM_TGI_INFERENCE_0_9_3,
+                    container:
+                      ContainerImages.HF_PYTORCH_LLM_TGI_INFERENCE_0_9_3,
                     instanceType: "ml.g5.12xlarge",
                     // https://github.com/awslabs/extending-the-context-length-of-open-source-llms/blob/main/custom-tgi-ecr/deploy.ipynb
                     containerStartupHealthCheckTimeoutInSeconds: 600,
@@ -78,295 +75,308 @@ export class Models extends Construct {
               ),
           },
         ],
-      },
+      }
     );
 
     new ssm.StringParameter(this, "FalconLiteProductParams", {
       parameterName: `/${productOwner}/products/${falconLiteProduct.productId}`,
       simpleName: false,
       stringValue: JSON.stringify({
-        "provider": "sagemaker",
-        "name": falconLiteModelId.split("/").join("-").split(".").join("-"),
-        "streaming": false,
-        "inputModalities": [Modality.Text],
-        "outputModalities": [Modality.Text],
-        "interface": ModelInterface.LangChain,
-        "ragSupported": true,
-      })
-    })
+        provider: "sagemaker",
+        name: falconLiteModelId.split("/").join("-").split(".").join("-"),
+        modelId: falconLiteModelId,
+        streaming: false,
+        inputModalities: [Modality.Text],
+        outputModalities: [Modality.Text],
+        interface: ModelInterface.LangChain,
+        ragSupported: true,
+        productId: falconLiteProduct.productId,
+      }),
+    });
 
-    const mistral7bInstructModelId = "mistralai/Mistral-7B-Instruct-v0.1"
+    const mistral7bInstructModelId = "mistralai/Mistral-7B-Instruct-v0.1";
     const mistral7bInstructProduct = new servicecatalog.CloudFormationProduct(
-        this,
-        "Mistral7bInstructProduct",
-        {
-          owner: productOwner,
-          productName: "Mistral7BInstruct",
-          productVersions: [
-            {
-              cloudFormationTemplate:
-                servicecatalog.CloudFormationTemplate.fromProductStack(
-                  new SageMakerModelProduct(
-                    this,
-                    "Mistral7BInstruct",
-                    {
-                      assetBucket: portfolioAssetBucket,
-                      vpc: props.shared.vpc,
-                      securityGroupId: defaultSecurityGroup,
-                      region: cdk.Aws.REGION,
-                      model: {
-                        type: DeploymentType.Container,
-                        modelId: mistral7bInstructModelId,
-                        container: ContainerImages.HF_PYTORCH_LLM_TGI_INFERENCE_1_1_0,
-                        instanceType: "ml.g5.2xlarge",
-                        containerStartupHealthCheckTimeoutInSeconds: 300,
-                        env: {
-                          SM_NUM_GPUS: JSON.stringify(1),
-                          MAX_INPUT_LENGTH: JSON.stringify(2048),
-                          MAX_TOTAL_TOKENS: JSON.stringify(4096),
-                          //HF_MODEL_QUANTIZE: "bitsandbytes",
-                        },
-                      },
-                      responseStreamingSupported: false,
-                      inputModalities: [Modality.Text],
-                      outputModalities: [Modality.Text],
-                      interface: ModelInterface.LangChain,
-                      ragSupported: true,
-                    }
-                  )
-                ),
-            },
-          ],
-        }
-      );
+      this,
+      "Mistral7bInstructProduct",
+      {
+        owner: productOwner,
+        productName: "Mistral7BInstruct",
+        productVersions: [
+          {
+            cloudFormationTemplate:
+              servicecatalog.CloudFormationTemplate.fromProductStack(
+                new SageMakerModelProduct(this, "Mistral7BInstruct", {
+                  assetBucket: portfolioAssetBucket,
+                  vpc: props.shared.vpc,
+                  securityGroupId: defaultSecurityGroup,
+                  region: cdk.Aws.REGION,
+                  model: {
+                    type: DeploymentType.Container,
+                    modelId: mistral7bInstructModelId,
+                    container:
+                      ContainerImages.HF_PYTORCH_LLM_TGI_INFERENCE_1_1_0,
+                    instanceType: "ml.g5.2xlarge",
+                    containerStartupHealthCheckTimeoutInSeconds: 300,
+                    env: {
+                      SM_NUM_GPUS: JSON.stringify(1),
+                      MAX_INPUT_LENGTH: JSON.stringify(2048),
+                      MAX_TOTAL_TOKENS: JSON.stringify(4096),
+                      //HF_MODEL_QUANTIZE: "bitsandbytes",
+                    },
+                  },
+                  responseStreamingSupported: false,
+                  inputModalities: [Modality.Text],
+                  outputModalities: [Modality.Text],
+                  interface: ModelInterface.LangChain,
+                  ragSupported: true,
+                })
+              ),
+          },
+        ],
+      }
+    );
 
-      new ssm.StringParameter(this, "mistral7bInstructProductParams", {
-        parameterName: `/${productOwner}/products/${mistral7bInstructProduct.productId}`,
-        simpleName: false,
-        stringValue: JSON.stringify({
-          "provider": "sagemaker",
-          "name": mistral7bInstructModelId.split("/").join("-").split(".").join("-"),
-          "streaming": false,
-          "inputModalities": [Modality.Text],
-          "outputModalities": [Modality.Text],
-          "interface": ModelInterface.LangChain,
-          "ragSupported": true,
-        })
-      })
+    new ssm.StringParameter(this, "mistral7bInstructProductParams", {
+      parameterName: `/${productOwner}/products/${mistral7bInstructProduct.productId}`,
+      simpleName: false,
+      stringValue: JSON.stringify({
+        provider: "sagemaker",
+        name: mistral7bInstructModelId
+          .split("/")
+          .join("-")
+          .split(".")
+          .join("-"),
+        modelId: mistral7bInstructModelId,
+        streaming: false,
+        inputModalities: [Modality.Text],
+        outputModalities: [Modality.Text],
+        interface: ModelInterface.LangChain,
+        ragSupported: true,
+        productId: mistral7bInstructProduct.productId,
+      }),
+    });
 
-      const llama2chatModelId = "meta-LLama2-13b-chat"
-      const llama2chatProduct = new servicecatalog.CloudFormationProduct(
-        this,
-        "LLamaV2_13B_ChatProduct",
-        {
-          owner: productOwner,
-          productName: "LLamaV2_13B_Chat",
-          productVersions: [
-            {
-              cloudFormationTemplate:
-                servicecatalog.CloudFormationTemplate.fromProductStack(
-                  new SageMakerModelProduct(this, "LLamaV2_13B_Chat", {
-                    assetBucket: portfolioAssetBucket,
-                    vpc: props.shared.vpc,
-                    securityGroupId: defaultSecurityGroup,
-                    region: cdk.Aws.REGION,
-                    model: {
-                      type: DeploymentType.ModelPackage,
-                      modelId: llama2chatModelId,
-                      instanceType: "ml.g5.12xlarge",
-                      packages: (scope) =>
-                        new cdk.CfnMapping(scope, "Llama2ChatPackageMapping", {
-                          lazy: true,
-                          mapping: {
-                            "ap-southeast-1": {
-                              arn: `arn:aws:sagemaker:ap-southeast-1:192199979996:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
-                            },
-                            "ap-southeast-2": {
-                              arn: `arn:aws:sagemaker:ap-southeast-2:666831318237:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
-                            },
-                            "eu-west-1": {
-                              arn: `arn:aws:sagemaker:eu-west-1:985815980388:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
-                            },
-                            "us-east-1": {
-                              arn: `arn:aws:sagemaker:us-east-1:865070037744:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
-                            },
-                            "us-east-2": {
-                              arn: `arn:aws:sagemaker:us-east-2:057799348421:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
-                            },
-                            "us-west-2": {
-                              arn: `arn:aws:sagemaker:us-west-2:594846645681:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
-                            },
+    const llama2chatModelId = "meta-LLama2-13b-chat";
+    const llama2chatProduct = new servicecatalog.CloudFormationProduct(
+      this,
+      "LLamaV2_13B_ChatProduct",
+      {
+        owner: productOwner,
+        productName: "LLamaV2_13B_Chat",
+        productVersions: [
+          {
+            cloudFormationTemplate:
+              servicecatalog.CloudFormationTemplate.fromProductStack(
+                new SageMakerModelProduct(this, "LLamaV2_13B_Chat", {
+                  assetBucket: portfolioAssetBucket,
+                  vpc: props.shared.vpc,
+                  securityGroupId: defaultSecurityGroup,
+                  region: cdk.Aws.REGION,
+                  model: {
+                    type: DeploymentType.ModelPackage,
+                    modelId: llama2chatModelId,
+                    instanceType: "ml.g5.12xlarge",
+                    packages: (scope) =>
+                      new cdk.CfnMapping(scope, "Llama2ChatPackageMapping", {
+                        lazy: true,
+                        mapping: {
+                          "ap-southeast-1": {
+                            arn: `arn:aws:sagemaker:ap-southeast-1:192199979996:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
                           },
-                        }),
+                          "ap-southeast-2": {
+                            arn: `arn:aws:sagemaker:ap-southeast-2:666831318237:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
+                          },
+                          "eu-west-1": {
+                            arn: `arn:aws:sagemaker:eu-west-1:985815980388:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
+                          },
+                          "us-east-1": {
+                            arn: `arn:aws:sagemaker:us-east-1:865070037744:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
+                          },
+                          "us-east-2": {
+                            arn: `arn:aws:sagemaker:us-east-2:057799348421:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
+                          },
+                          "us-west-2": {
+                            arn: `arn:aws:sagemaker:us-west-2:594846645681:model-package/llama2-13b-f-v4-55c7c39a0cf535e8bad0d342598c219b`,
+                          },
+                        },
+                      }),
+                  },
+                  responseStreamingSupported: false,
+                  inputModalities: [Modality.Text],
+                  outputModalities: [Modality.Text],
+                  interface: ModelInterface.LangChain,
+                  ragSupported: true,
+                })
+              ),
+          },
+        ],
+      }
+    );
+
+    new ssm.StringParameter(this, "LLamaV2_13B_ChatProductParams", {
+      parameterName: `/${productOwner}/products/${llama2chatProduct.productId}`,
+      simpleName: false,
+      stringValue: JSON.stringify({
+        provider: "sagemaker",
+        name: llama2chatModelId.split("/").join("-").split(".").join("-"),
+        modelId: llama2chatModelId,
+        streaming: false,
+        inputModalities: [Modality.Text],
+        outputModalities: [Modality.Text],
+        interface: ModelInterface.LangChain,
+        ragSupported: true,
+        productId: llama2chatProduct.productId,
+      }),
+    });
+
+    const idefics9bModelId = "HuggingFaceM4/idefics-9b-instruct";
+    const idefics9bProduct = new servicecatalog.CloudFormationProduct(
+      this,
+      "IDEFICS9BProduct",
+      {
+        owner: productOwner,
+        productName: "IDEFICS9B",
+        productVersions: [
+          {
+            cloudFormationTemplate:
+              servicecatalog.CloudFormationTemplate.fromProductStack(
+                new SageMakerModelProduct(this, "IDEFICS9B", {
+                  assetBucket: portfolioAssetBucket,
+                  vpc: props.shared.vpc,
+                  securityGroupId: defaultSecurityGroup,
+                  region: cdk.Aws.REGION,
+                  model: {
+                    type: DeploymentType.Container,
+                    modelId: idefics9bModelId,
+                    container:
+                      ContainerImages.HF_PYTORCH_LLM_TGI_INFERENCE_1_1_0,
+                    instanceType: "ml.g5.12xlarge",
+                    containerStartupHealthCheckTimeoutInSeconds: 300,
+                    env: {
+                      SM_NUM_GPUS: JSON.stringify(4),
+                      MAX_INPUT_LENGTH: JSON.stringify(1024),
+                      MAX_TOTAL_TOKENS: JSON.stringify(2048),
+                      MAX_BATCH_TOTAL_TOKENS: JSON.stringify(8192),
                     },
-                    responseStreamingSupported: false,
-                    inputModalities: [Modality.Text],
-                    outputModalities: [Modality.Text],
-                    interface: ModelInterface.LangChain,
-                    ragSupported: true,
-                  })
-                ),
-            },
-          ],
-        }
-      );
+                  },
+                  responseStreamingSupported: false,
+                  inputModalities: [Modality.Text, Modality.Image],
+                  outputModalities: [Modality.Text],
+                  interface: ModelInterface.Idefics,
+                  ragSupported: false,
+                })
+              ),
+          },
+        ],
+      }
+    );
 
-      new ssm.StringParameter(this, "LLamaV2_13B_ChatProductParams", {
-        parameterName: `/${productOwner}/products/${llama2chatProduct.productId}`,
-        simpleName: false,
-        stringValue: JSON.stringify({
-          "provider": "sagemaker",
-          "name": llama2chatModelId.split("/").join("-").split(".").join("-"),
-          "streaming": false,
-          "inputModalities": [Modality.Text],
-          "outputModalities": [Modality.Text],
-          "interface": ModelInterface.LangChain,
-          "ragSupported": true,
-        })
-      })
+    new ssm.StringParameter(this, "IDEFICS9BProductParams", {
+      parameterName: `/${productOwner}/products/${idefics9bProduct.productId}`,
+      simpleName: false,
+      stringValue: JSON.stringify({
+        provider: "sagemaker",
+        name: idefics9bModelId.split("/").join("-").split(".").join("-"),
+        modelId: idefics9bModelId,
+        streaming: false,
+        inputModalities: [Modality.Text, Modality.Image],
+        outputModalities: [Modality.Text],
+        interface: ModelInterface.Idefics,
+        ragSupported: false,
+        productId: idefics9bProduct.productId,
+      }),
+    });
 
-      const idefics9bModelId = "HuggingFaceM4/idefics-9b-instruct"
-      const idefics9bProduct = new servicecatalog.CloudFormationProduct(
-        this,
-        "IDEFICS9BProduct",
-        {
-          owner: productOwner,
-          productName: "IDEFICS9B",
-          productVersions: [
-            {
-              cloudFormationTemplate:
-                servicecatalog.CloudFormationTemplate.fromProductStack(
-                  new SageMakerModelProduct(this, "IDEFICS9B", {
-                    assetBucket: portfolioAssetBucket,
-                    vpc: props.shared.vpc,
-                    securityGroupId: defaultSecurityGroup,
-                    region: cdk.Aws.REGION,
-                    model: {
-                      type: DeploymentType.Container,
-                      modelId: idefics9bModelId,
-                      container: ContainerImages.HF_PYTORCH_LLM_TGI_INFERENCE_1_1_0,
-                      instanceType: "ml.g5.12xlarge",
-                      containerStartupHealthCheckTimeoutInSeconds: 300,
-                      env: {
-                        SM_NUM_GPUS: JSON.stringify(4),
-                        MAX_INPUT_LENGTH: JSON.stringify(1024),
-                        MAX_TOTAL_TOKENS: JSON.stringify(2048),
-                        MAX_BATCH_TOTAL_TOKENS: JSON.stringify(8192),
-                      },
+    const idefics80bModelId = "HuggingFaceM4/idefics-80b-instruct";
+    const idefics80bProduct = new servicecatalog.CloudFormationProduct(
+      this,
+      "IDEFICS80BProduct",
+      {
+        owner: productOwner,
+        productName: "IDEFICS80B",
+        productVersions: [
+          {
+            cloudFormationTemplate:
+              servicecatalog.CloudFormationTemplate.fromProductStack(
+                new SageMakerModelProduct(this, "IDEFICS80B", {
+                  assetBucket: portfolioAssetBucket,
+                  vpc: props.shared.vpc,
+                  securityGroupId: defaultSecurityGroup,
+                  region: cdk.Aws.REGION,
+                  model: {
+                    type: DeploymentType.Container,
+                    modelId: idefics80bModelId,
+                    container:
+                      ContainerImages.HF_PYTORCH_LLM_TGI_INFERENCE_1_1_0,
+                    instanceType: "ml.g5.48xlarge",
+                    containerStartupHealthCheckTimeoutInSeconds: 600,
+                    env: {
+                      SM_NUM_GPUS: JSON.stringify(8),
+                      MAX_INPUT_LENGTH: JSON.stringify(1024),
+                      MAX_TOTAL_TOKENS: JSON.stringify(2048),
+                      MAX_BATCH_TOTAL_TOKENS: JSON.stringify(8192),
+                      // quantization required to work with ml.g5.48xlarge
+                      // comment if deploying with ml.p4d or ml.p4e instances
+                      HF_MODEL_QUANTIZE: "bitsandbytes",
                     },
-                    responseStreamingSupported: false,
-                    inputModalities: [Modality.Text, Modality.Image],
-                    outputModalities: [Modality.Text],
-                    interface: ModelInterface.Idefics,
-                    ragSupported: false,
-                  })),
-            },
-          ],
-        }
-      );
+                  },
+                  responseStreamingSupported: false,
+                  inputModalities: [Modality.Text, Modality.Image],
+                  outputModalities: [Modality.Text],
+                  interface: ModelInterface.Idefics,
+                  ragSupported: false,
+                })
+              ),
+          },
+        ],
+      }
+    );
 
-      new ssm.StringParameter(this, "IDEFICS9BProductParams", {
-        parameterName: `/${productOwner}/products/${idefics9bProduct.productId}`,
-        simpleName: false,
-        stringValue: JSON.stringify({
-          "provider": "sagemaker",
-          "name": idefics9bModelId.split("/").join("-").split(".").join("-"),
-          "streaming": false,
-          "inputModalities": [Modality.Text, Modality.Image],
-          "outputModalities": [Modality.Text],
-          "interface": ModelInterface.Idefics,
-          "ragSupported": false,
-        })
-      })
-      
-      const idefics80bModelId = "HuggingFaceM4/idefics-80b-instruct"
-      const idefics80bProduct = new servicecatalog.CloudFormationProduct(
-        this,
-        "IDEFICS80BProduct",
-        {
-          owner: productOwner,
-          productName: "IDEFICS80B",
-          productVersions: [
-            {
-              cloudFormationTemplate:
-                servicecatalog.CloudFormationTemplate.fromProductStack(
-                  new SageMakerModelProduct(this, "IDEFICS80B", {
-                    assetBucket: portfolioAssetBucket,
-                    vpc: props.shared.vpc,
-                    securityGroupId: defaultSecurityGroup,
-                    region: cdk.Aws.REGION,
-                    model: {
-                      type: DeploymentType.Container,
-                      modelId: idefics80bModelId,
-                      container: ContainerImages.HF_PYTORCH_LLM_TGI_INFERENCE_1_1_0,
-                      instanceType: "ml.g5.48xlarge",
-                      containerStartupHealthCheckTimeoutInSeconds: 600,
-                      env: {
-                        SM_NUM_GPUS: JSON.stringify(8),
-                        MAX_INPUT_LENGTH: JSON.stringify(1024),
-                        MAX_TOTAL_TOKENS: JSON.stringify(2048),
-                        MAX_BATCH_TOTAL_TOKENS: JSON.stringify(8192),
-                        // quantization required to work with ml.g5.48xlarge
-                        // comment if deploying with ml.p4d or ml.p4e instances
-                        HF_MODEL_QUANTIZE: "bitsandbytes",
-                      },
-                    },
-                    responseStreamingSupported: false,
-                    inputModalities: [Modality.Text, Modality.Image],
-                    outputModalities: [Modality.Text],
-                    interface: ModelInterface.Idefics,
-                    ragSupported: false,
-                  })
-                ),
-            },
-          ],
-        }
-      );
+    new ssm.StringParameter(this, "IDEFICS80BProductParams", {
+      parameterName: `/${productOwner}/products/${idefics80bProduct.productId}`,
+      simpleName: false,
+      stringValue: JSON.stringify({
+        provider: "sagemaker",
+        modelId: idefics80bModelId,
+        streaming: false,
+        inputModalities: [Modality.Text, Modality.Image],
+        outputModalities: [Modality.Text],
+        interface: ModelInterface.Idefics,
+        ragSupported: false,
+        productId: idefics80bProduct.productId,
+      }),
+    });
 
-      new ssm.StringParameter(this, "IDEFICS80BProductParams", {
-        parameterName: `/${productOwner}/products/${idefics80bProduct.productId}`,
-        simpleName: false,
-        stringValue: JSON.stringify({
-          "provider": "sagemaker",
-          "name": idefics80bModelId.split("/").join("-").split(".").join("-"),
-          "streaming": false,
-          "inputModalities": [Modality.Text, Modality.Image],
-          "outputModalities": [Modality.Text],
-          "interface": ModelInterface.Idefics,
-          "ragSupported": false,
-        })
-      })
+    //Add all the declared products to a portfolio.
+    const portfolio = new servicecatalog.Portfolio(this, "ModelsPortfolio", {
+      displayName: "GenAI Chatbot SageMaker Models",
+      providerName: productOwner,
+      description:
+        "Models that can be launched to be used with the GenAI Chatbot",
+    });
 
-      //Add all the declared products to a portfolio.
-      const portfolio = new servicecatalog.Portfolio(this, "ModelsPortfolio", {
-        displayName: "GenAI Chatbot SageMaker Models",
-        providerName: productOwner,
-        description:
-          "Models that can be launched to be used with the GenAI Chatbot",
-      });
+    new ssm.StringParameter(this, "ProductsConfig", {
+      parameterName: `/${productOwner}/products-config`,
+      stringValue: JSON.stringify({
+        vpcId: props.shared.vpc.vpcId,
+        defaultSecurityGroupId: defaultSecurityGroup,
+        privateSubnets: props.shared.vpc.privateSubnets.map(
+          (subnet) => subnet.subnetId
+        ),
+        restApiIamRole: props.chatBotApi.apiHandler.role?.roleArn,
+        productOwner: productOwner,
+      }),
+    });
 
-      new ssm.StringParameter(this, "ProductsConfig", {
-        parameterName: `/${productOwner}/products/config`,
-        stringValue: JSON.stringify({
-          vpcId: props.shared.vpc.vpcId,
-          defaultSecurityGroup: defaultSecurityGroup,
-          privateSubnets: props.shared.vpc.privateSubnets.map(subnet => subnet.subnetId),
-          restApiIamRole: props.chatBotApi.apiHandler.role?.roleArn,
-          productOwner: productOwner,
-        })
-      })
-
-    if(props.chatBotApi.apiHandler.role) {
+    if (props.chatBotApi.apiHandler.role) {
       portfolio.giveAccessToRole(props.chatBotApi.apiHandler.role);
       props.chatBotApi.apiHandler.role.addToPrincipalPolicy(
         new iam.PolicyStatement({
-          actions: [
-            "servicecatalog:SearchProducts"
-          ],
+          actions: ["servicecatalog:SearchProducts"],
           resources: ["*"],
           effect: iam.Effect.ALLOW,
         })
-      )
+      );
     }
     portfolio.addProduct(falconLiteProduct);
     portfolio.addProduct(mistral7bInstructProduct);
@@ -384,6 +394,5 @@ export class Models extends Construct {
     //      model_id = 'meta-textgeneration-llama-2-13b-f'
     //      model = JumpStartModel(model_id=model_id, region=region)
     //      print(model.model_package_arn)
-
   }
 }

--- a/lib/rag-engines/sagemaker-rag-models/index.ts
+++ b/lib/rag-engines/sagemaker-rag-models/index.ts
@@ -26,6 +26,7 @@ export class SageMakerRagModels extends Construct {
 
     const model = new SageMakerModel(this, "Model", {
       vpc: props.shared.vpc,
+      securityGroupId: props.shared.vpc.vpcDefaultSecurityGroup,
       region: cdk.Aws.REGION,
       model: {
         type: DeploymentType.CustomInferenceScript,

--- a/lib/sagemaker-model/deploy-container-model.ts
+++ b/lib/sagemaker-model/deploy-container-model.ts
@@ -1,4 +1,3 @@
-import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as sagemaker from "aws-cdk-lib/aws-sagemaker";
 import { Construct } from "constructs";
@@ -54,8 +53,12 @@ export function deployContainerModel(
     executionRoleArn: executionRole.roleArn,
     ...modelProps,
     vpcConfig: {
-      securityGroupIds: [props.vpc.vpcDefaultSecurityGroup],
-      subnets: props.vpc.privateSubnets.map((subnet) => subnet.subnetId),
+      securityGroupIds: [
+        props.securityGroupId ?? props.vpc!.vpcDefaultSecurityGroup,
+      ],
+      subnets:
+        props.privateSubnets ??
+        props.vpc!.privateSubnets.map((subnet) => subnet.subnetId),
     },
   });
 

--- a/lib/sagemaker-model/deploy-custom-script-model.ts
+++ b/lib/sagemaker-model/deploy-custom-script-model.ts
@@ -24,7 +24,6 @@ export function deployCustomScriptModel(
     .replace(/[^a-zA-Z0-9]/g, "")
     .slice(-10);
   const llmModel = new HuggingFaceCustomScriptModel(scope, endpointName, {
-    vpc,
     region,
     modelId,
     instanceType,

--- a/lib/sagemaker-model/hf-custom-script-model/index.ts
+++ b/lib/sagemaker-model/hf-custom-script-model/index.ts
@@ -14,7 +14,6 @@ import { ContainerImages } from "../container-images";
 import { ImageRepositoryMapping } from "../image-repository-mapping";
 
 export interface HuggingFaceCustomScriptModelProps {
-  vpc: ec2.Vpc;
   region: string;
   instanceType: string;
   modelId: string | string[];

--- a/lib/sagemaker-model/index.ts
+++ b/lib/sagemaker-model/index.ts
@@ -1,22 +1,53 @@
 export * from "./container-images";
 export * from "./types";
+import * as servicecatalog from "aws-cdk-lib/aws-servicecatalog";
 import * as sagemaker from "aws-cdk-lib/aws-sagemaker";
+import * as ssm from "aws-cdk-lib/aws-ssm";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { Construct } from "constructs";
 import { deployContainerModel } from "./deploy-container-model";
 import { deployCustomScriptModel } from "./deploy-custom-script-model";
 import { deployPackageModel } from "./deploy-package-model";
 import { DeploymentType, SageMakerModelProps } from "./types";
+import { Vpc } from "aws-cdk-lib/aws-ec2";
+import { CfnParameter } from "aws-cdk-lib";
 
+export class SageMakerModelProduct extends servicecatalog.ProductStack {
+  constructor(scope: Construct, id: string, props: SageMakerModelProps) {
+    super(scope, id);
+    const vpcId = new CfnParameter(this, "VpcId", {
+      type: "AWS::EC2::VPC::Id",
+    });
+    const defaultSecurityGroupId = new CfnParameter(
+      this,
+      "DefaultSecurityGroupId",
+      {
+        type: "AWS::EC2::SecurityGroup::Id",
+      }
+    );
+    const privateSubnets = new CfnParameter(this, "PrivateSubnets", {
+      type: "List<AWS::EC2::Subnet::Id>",
+    });
+    let modelProps = props;
+    modelProps.privateSubnets = privateSubnets.valueAsList
+    modelProps.vpcId = vpcId.valueAsString
+    modelProps.securityGroupId = defaultSecurityGroupId.valueAsString
+    new SageMakerModel(this, id, modelProps);
+  }
+}
 export class SageMakerModel extends Construct {
   public readonly endpoint: sagemaker.CfnEndpoint;
   public readonly modelId: string | string[];
 
-  constructor(scope: Construct, id: string, props: SageMakerModelProps) {
+  constructor(
+    scope: Construct,
+    id: string,
+    props: SageMakerModelProps,
+  ) {
     super(scope, id);
-
+    const MODEL_PARAMETER_PATH = "chatbot/models";
     const { model } = props;
     this.modelId = model.modelId;
-
     if (model.type == DeploymentType.Container) {
       const { endpoint } = deployContainerModel(this, props, model);
       this.endpoint = endpoint;
@@ -27,5 +58,25 @@ export class SageMakerModel extends Construct {
       const { endpoint } = deployCustomScriptModel(this, props, model);
       this.endpoint = endpoint;
     }
+
+    new ssm.StringParameter(scope, "ModelsParameter", {
+      parameterName: `/${MODEL_PARAMETER_PATH}/${id}`,
+      stringValue: JSON.stringify({
+        name: id,
+        endpoint: this.endpoint.ref,
+        responseStreamingSupported: props.responseStreamingSupported,
+        inputModalities: props.inputModalities,
+        outputModalities: props.outputModalities,
+        interface: props.interface,
+        ragSupported: props.ragSupported,
+      }),
+    });
+
+    // props.apiHandler?.addToRolePolicy(
+    //   new iam.PolicyStatement({
+    //     actions: ["sagemaker:InvokeEndpoint"],
+    //     resources: [this.endpoint.ref],
+    //   })
+    // );
   }
 }

--- a/lib/sagemaker-model/types.ts
+++ b/lib/sagemaker-model/types.ts
@@ -20,9 +20,8 @@ export interface SageMakerModelProps extends servicecatalog.ProductStackProps {
   modelName?: string;
   restApiIamRole?: string;
   productOwner?: string;
+  productId?: string;
 }
-
-
 
 export enum DeploymentType {
   Container = "container",

--- a/lib/sagemaker-model/types.ts
+++ b/lib/sagemaker-model/types.ts
@@ -2,12 +2,26 @@ import * as cdk from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
+import * as servicecatalog from "aws-cdk-lib/aws-servicecatalog";
+import { Modality, ModelInterface } from "../shared/types";
 
-export interface SageMakerModelProps extends cdk.NestedStackProps {
-  vpc: ec2.Vpc;
+export interface SageMakerModelProps extends servicecatalog.ProductStackProps {
+  vpc?: ec2.Vpc;
+  vpcId?: string;
+  privateSubnets?: string[];
+  securityGroupId: string;
   region: string;
   model: ModelConfig;
+  responseStreamingSupported?: boolean;
+  inputModalities?: Modality[];
+  outputModalities?: Modality[];
+  interface?: ModelInterface;
+  ragSupported?: boolean;
+  apiHandler?: lambda.Function;
+  modelName?: string;
 }
+
+export interface SageMakerModelProductProps extends SageMakerModelProps {}
 
 export enum DeploymentType {
   Container = "container",

--- a/lib/sagemaker-model/types.ts
+++ b/lib/sagemaker-model/types.ts
@@ -17,11 +17,12 @@ export interface SageMakerModelProps extends servicecatalog.ProductStackProps {
   outputModalities?: Modality[];
   interface?: ModelInterface;
   ragSupported?: boolean;
-  apiHandler?: lambda.Function;
   modelName?: string;
+  restApiIamRole?: string;
+  productOwner?: string;
 }
 
-export interface SageMakerModelProductProps extends SageMakerModelProps {}
+
 
 export enum DeploymentType {
   Container = "container",

--- a/lib/shared/layers/python-sdk/python/genai_core/clients.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/clients.py
@@ -53,5 +53,6 @@ def get_bedrock_client(service_name="bedrock-runtime"):
 
     return boto3.client(**bedrock_config_data)
 
+
 def get_service_catalog_client():
-    return boto3.client('servicecatalog')
+    return boto3.client("servicecatalog")

--- a/lib/shared/layers/python-sdk/python/genai_core/clients.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/clients.py
@@ -52,3 +52,6 @@ def get_bedrock_client(service_name="bedrock-runtime"):
         bedrock_config_data["aws_session_token"] = credentials["SessionToken"]
 
     return boto3.client(**bedrock_config_data)
+
+def get_service_catalog_client():
+    return boto3.client('servicecatalog')

--- a/lib/shared/layers/python-sdk/python/genai_core/models.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/models.py
@@ -112,7 +112,12 @@ def list_bedrock_finetuned_models():
 
 
 def list_sagemaker_models():
-    models = genai_core.parameters.get_sagemaker_models()
+    parameters = genai_core.parameters.get_sagemaker_models()
+    if parameters is None:
+        return None
+    
+    models = parameters.get("Parameters", [])
+
 
     return [
         {

--- a/lib/shared/layers/python-sdk/python/genai_core/models.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/models.py
@@ -6,6 +6,7 @@ import genai_core.parameters
 from genai_core.types import Modality, Provider, ModelInterface
 
 
+
 def list_models():
     models = []
 
@@ -17,13 +18,25 @@ def list_models():
     if fine_tuned_models:
         models.extend(fine_tuned_models)
 
+    """Get SageMaker Models that are deployed
+    Then get Service Catalog Products of Deployable Models
+    Compare deployed models to products to determine if
+    a model is deployed or not AND if it's deployable or not
+    (for example, if SageMaker models are added but not through SC)
+    """
     sagemaker_models = list_sagemaker_models()
-    if sagemaker_models:
-        models.extend(sagemaker_models)
 
     provisionable_sagemaker_models = list_provisionable_sagemaker_models()
-    if provisionable_sagemaker_models:
+    if provisionable_sagemaker_models and sagemaker_models:
+        models.extend(
+            merge_deployed_and_provisionable_models(
+                sagemaker_models, provisionable_sagemaker_models
+            )
+        )
+    elif provisionable_sagemaker_models:
         models.extend(provisionable_sagemaker_models)
+    elif sagemaker_models:
+        models.extend(sagemaker_models)
 
     openai_models = list_openai_models()
     if openai_models:
@@ -119,53 +132,94 @@ def list_bedrock_finetuned_models():
         print(f"Error listing fine-tuned Bedrock models: {e}")
         return None
 
-
+# TODO - shift away from parameter store and toward provisioned products 
 def list_sagemaker_models():
-    parameters = genai_core.parameters.get_sagemaker_models()
-    if parameters is None:
+    models = genai_core.parameters.get_sagemaker_models()
+    if models is None:
         return None
-
-    models = parameters.get("Parameters", [])
 
     return [
         {
             "provider": Provider.SAGEMAKER.value,
-            "name": model["name"],
-            "streaming": model.get("responseStreamingSupported", False),
-            "inputModalities": model["inputModalities"],
-            "outputModalities": model["outputModalities"],
-            "interface": model["interface"],
-            "ragSupported": model["ragSupported"],
+            "name": modelConfig.get("name",modelConfig.get("modelId", None)),
+            "modelId": modelConfig.get("modelId", None),
+            "streaming": modelConfig.get("responseStreamingSupported", False),
+            "inputModalities": modelConfig["inputModalities"],
+            "outputModalities": modelConfig["outputModalities"],
+            "interface": modelConfig["interface"],
+            "ragSupported": modelConfig["ragSupported"],
+            "productId": modelConfig.get("productId", None),
         }
-        for model in models
+        for modelKey, modelConfig in models.items()
     ]
 
+# TODO - Check for provisioned products in service catalog
 def list_provisionable_sagemaker_models():
     service_catalog = genai_core.clients.get_service_catalog_client()
     product_owner = genai_core.parameters.get_root_parameter_path()
-    products = service_catalog.search_products(
+    products_results = service_catalog.search_products(
         Filters={
-            'Owner': [product_owner],
+            "Owner": [product_owner],
         }
     )
-    
+
+    products = products_results.get("ProductViewSummaries", [])
+
     product_details = genai_core.parameters.get_provisionable_sagemaker_model_details()
-    if product_details['Parameters'] is None:
+    if product_details is None:
         return []
-    
+
+    # Loop through products in service catalog and return the details from Parameter Store for the productId
+    return [
+        {
+            "provider": Provider.SAGEMAKER.value,
+            "name": product_details[product["ProductId"]]["modelId"],
+            "modelId": product_details[product["ProductId"]]["modelId"],
+            "streaming": product_details[product["ProductId"]].get("streaming", False),
+            "inputModalities": product_details[product["ProductId"]].get(
+                "inputModalities", []
+            ),
+            "outputModalities": product_details[product["ProductId"]].get(
+                "outputModalities", []
+            ),
+            "interface": product_details[product["ProductId"]]["interface"],
+            "ragSupported": product_details[product["ProductId"]]["ragSupported"],
+            "productId": product_details[product["ProductId"]].get("productId", None),
+            "deployed": False,  # Set to False by default, will be set to True if model is deployed in Service Catalog
+        }
+        for product in products
+        if product["ProductId"] in product_details.keys()
+    ]
+
+
+def merge_deployed_and_provisionable_models(
+    sagemaker_models, provisionable_sagemaker_models
+):
     models = []
-    for product in products.get('ProductViewSummaries', []):
-        param_name = f'/{genai_core.parameters.get_root_parameter_path()}/products/{product["ProductId"]}'
-        model = [json.loads(details['Value']) for details in product_details if details["Name"] == param_name]
-        models.extend({
-            "provider": Provider.SERVICECATALOG.value,
-            "name": model["name"],
-            "streaming": model.get("responseStreamingSupported", False),
-            "inputModalities": model["inputModalities"],
-            "outputModalities": model["outputModalities"],
-            "interface": model["interface"],
-            "ragSupported": model["ragSupported"],
-        })
+    # Compare the SC Products with the existing SageMaker Models to determine which ones are deployed
+    for model in provisionable_sagemaker_models:
+        if not any(m["productId"] == model["productId"] for m in sagemaker_models):
+            model["deployed"] = False
+        else:
+            model["deployed"] = True
+        models.append(model)
+    # Check merged models for any deployed models that may not be in Service Catalog and add them back in.
+    for model in sagemaker_models:
+        if not any(m["productId"] == model["productId"] for m in models):
+            models.append(model)
     return models
 
+
+
+def deploy_model(product_id):
+    product_config = genai_core.parameters.get_product_config()
+    product_config['productId'] = product_id
+    service_catalog = genai_core.clients.get_service_catalog_client()
+    service_catalog.provision_product(
+        ProductId=product_id,
+        ProvisioningParameters=[{
+            'Key': key,
+            'Value': value
+        } for key, value in product_config.items()]
+    )
     

--- a/lib/shared/layers/python-sdk/python/genai_core/models.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/models.py
@@ -70,8 +70,10 @@ def list_bedrock_models():
             }
             for model in bedrock_models
             # Exclude embeddings and stable diffusion models
-            if Modality.EMBEDDING.value not in model["outputModalities"]
-            and Modality.IMAGE.value not in model["outputModalities"]
+            if model.get("inputModalities", None) != None
+            and model.get("outputModalities", None) != None
+            and Modality.EMBEDDING.value not in model.get("outputModalities", [])
+            and Modality.IMAGE.value not in model.get("outputModalities", [])
         ]
 
         return models
@@ -101,13 +103,15 @@ def list_bedrock_finetuned_models():
             }
             for model in bedrock_custom_models
             # Exclude embeddings and stable diffusion models
-            if Modality.EMBEDDING.value not in model["outputModalities"]
-            and Modality.IMAGE.value not in model["outputModalities"]
+            if model.get("inputModalities", None) != None
+            and model.get("outputModalities", None) != None
+            and Modality.EMBEDDING.value not in model.get("outputModalities", [])
+            and Modality.IMAGE.value not in model.get("outputModalities", [])
         ]
 
         return models
     except Exception as e:
-        print(f"Error listing Bedrock models: {e}")
+        print(f"Error listing fine-tuned Bedrock models: {e}")
         return None
 
 
@@ -115,9 +119,8 @@ def list_sagemaker_models():
     parameters = genai_core.parameters.get_sagemaker_models()
     if parameters is None:
         return None
-    
-    models = parameters.get("Parameters", [])
 
+    models = parameters.get("Parameters", [])
 
     return [
         {

--- a/lib/shared/layers/python-sdk/python/genai_core/parameters.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/parameters.py
@@ -30,5 +30,5 @@ def get_config():
     return config
 
 
-def get_sagemaker_models():
-    return parameters.get_parameter(MODELS_PARAMETER_NAME, transform="json", max_age=30)
+def get_sagemaker_models(): 
+    return parameters.get_parameters(MODELS_PARAMETER_NAME, transform="json", max_age=30)

--- a/lib/shared/layers/python-sdk/python/genai_core/parameters.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/parameters.py
@@ -29,13 +29,22 @@ def get_config():
 
     return config
 
+
 def get_root_parameter_path():
     config = get_config()
-    return config.get("prefix","") + "GenAIChatBotStack"
+    return config.get("prefix", "") + "GenAIChatBotStack"
 
-def get_sagemaker_models(): 
-    return parameters.get_parameters(MODELS_PARAMETER_NAME, transform="json", max_age=30)
+def get_product_config():
+    return parameters.get_parameter(
+        f"/{get_root_parameter_path()}/products-config"
+    )
+
+def get_sagemaker_models():
+    return parameters.get_parameters(
+        f"/{get_root_parameter_path()}/chatbot/models/", transform="json", max_age=30
+    )
+
 
 def get_provisionable_sagemaker_model_details():
-    path = f'/{get_root_parameter_path()}/products/'
+    path = f"/{get_root_parameter_path()}/products/"
     return parameters.get_parameters(path, transform="json", max_age=30)

--- a/lib/shared/layers/python-sdk/python/genai_core/parameters.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/parameters.py
@@ -29,6 +29,13 @@ def get_config():
 
     return config
 
+def get_root_parameter_path():
+    config = get_config()
+    return config.get("prefix","") + "GenAIChatBotStack"
 
 def get_sagemaker_models(): 
     return parameters.get_parameters(MODELS_PARAMETER_NAME, transform="json", max_age=30)
+
+def get_provisionable_sagemaker_model_details():
+    path = f'/{get_root_parameter_path()}/products/'
+    return parameters.get_parameters(path, transform="json", max_age=30)

--- a/lib/shared/layers/python-sdk/python/genai_core/types.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/types.py
@@ -31,6 +31,7 @@ class Provider(Enum):
     BEDROCK = "bedrock"
     OPENAI = "openai"
     SAGEMAKER = "sagemaker"
+    SERVICECATALOG = "servicecatalog"
 
 
 class Modality(Enum):

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -106,6 +106,8 @@ export interface SystemConfig {
   };
 }
 
+export const MODEL_PARAMETER_PATH = "chatbot/models";
+
 export interface SageMakerLLMEndpoint {
   name: string;
   endpoint: sagemaker.CfnEndpoint;

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -106,7 +106,7 @@ export interface SystemConfig {
   };
 }
 
-export const MODEL_PARAMETER_PATH = "chatbot/models";
+
 
 export interface SageMakerLLMEndpoint {
   name: string;

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -106,8 +106,6 @@ export interface SystemConfig {
   };
 }
 
-
-
 export interface SageMakerLLMEndpoint {
   name: string;
   endpoint: sagemaker.CfnEndpoint;

--- a/lib/user-interface/react-app/src/common/types.ts
+++ b/lib/user-interface/react-app/src/common/types.ts
@@ -58,7 +58,7 @@ export interface ApiErrorResult {
 }
 
 export type LoadingStatus = "pending" | "loading" | "finished" | "error";
-export type ModelProvider = "sagemaker" | "bedrock" | "openai";
+export type ModelProvider = "sagemaker" | "bedrock" | "openai" | "servicecatalog";
 export type RagDocumentType =
   | "file"
   | "text"

--- a/lib/user-interface/react-app/src/common/types.ts
+++ b/lib/user-interface/react-app/src/common/types.ts
@@ -58,7 +58,11 @@ export interface ApiErrorResult {
 }
 
 export type LoadingStatus = "pending" | "loading" | "finished" | "error";
-export type ModelProvider = "sagemaker" | "bedrock" | "openai" | "servicecatalog";
+export type ModelProvider =
+  | "sagemaker"
+  | "bedrock"
+  | "openai"
+  | "servicecatalog";
 export type RagDocumentType =
   | "file"
   | "text"
@@ -122,6 +126,7 @@ export interface ModelItem {
   outputModalities: Modality[];
   interface: ModelInterface;
   ragSupported: boolean;
+  deployed?: boolean;
 }
 
 export interface SessionItem {

--- a/lib/user-interface/react-app/src/pages/chatbot/models/column-definitions.tsx
+++ b/lib/user-interface/react-app/src/pages/chatbot/models/column-definitions.tsx
@@ -11,7 +11,7 @@ export const ModelsColumnDefinitions: TableProps.ColumnDefinition<ModelItem>[] =
       id: "provider",
       header: "Provider",
       sortingField: "provider",
-      cell: (item: ModelItem) => item.provider,
+      cell: (item: ModelItem) => item.provider != "servicecatalog" ? item.provider : "sagemaker",
     },
     {
       id: "name",
@@ -24,26 +24,32 @@ export const ModelsColumnDefinitions: TableProps.ColumnDefinition<ModelItem>[] =
       id: "ragSupported",
       header: "RAG Supported",
       sortingField: "ragSupported",
-      cell: (item: ModelItem) => (item.ragSupported ? "Yes" : "No"),
+      cell: (item: ModelItem) => item.ragSupported != undefined ? (item.ragSupported ? "Yes" : "No") : "",
     },
     {
       id: "inputModalities",
       header: "Input modalities",
       sortingField: "inputModalities",
-      cell: (item: ModelItem) => item.inputModalities.join(", "),
+      cell: (item: ModelItem) => item.inputModalities ? item.inputModalities.join(", ") : "",
     },
     {
       id: "outputModalities",
       header: "Output modalities",
       sortingField: "outputModalities",
-      cell: (item: ModelItem) => item.outputModalities.join(", "),
+      cell: (item: ModelItem) => item.outputModalities ? item.outputModalities.join(", ") : "",
     },
     {
       id: "streaming",
       header: "Streaming",
       sortingField: "streaming",
-      cell: (item: ModelItem) => (item.streaming ? "Yes" : "No"),
+      cell: (item: ModelItem) => item.streaming != undefined ? (item.streaming ? "Yes" : "No") : "",
     },
+    {
+      id: "availability",
+      header: "Model Availability",
+      sortingField: "availability",
+      cell: (item: ModelItem) => item.provider != "servicecatalog" ? <>Available</> : <>Deployable!</>,
+    }
   ];
 
 export const ModelsColumnFilteringProperties: PropertyFilterProperty[] = [

--- a/lib/user-interface/react-app/src/pages/chatbot/models/column-definitions.tsx
+++ b/lib/user-interface/react-app/src/pages/chatbot/models/column-definitions.tsx
@@ -1,4 +1,4 @@
-import { TableProps } from "@cloudscape-design/components";
+import { Badge, TableProps } from "@cloudscape-design/components";
 import {
   PropertyFilterProperty,
   PropertyFilterOperator,
@@ -11,7 +11,8 @@ export const ModelsColumnDefinitions: TableProps.ColumnDefinition<ModelItem>[] =
       id: "provider",
       header: "Provider",
       sortingField: "provider",
-      cell: (item: ModelItem) => item.provider != "servicecatalog" ? item.provider : "sagemaker",
+      cell: (item: ModelItem) =>
+        item.provider != "servicecatalog" ? item.provider : "sagemaker",
     },
     {
       id: "name",
@@ -24,32 +25,45 @@ export const ModelsColumnDefinitions: TableProps.ColumnDefinition<ModelItem>[] =
       id: "ragSupported",
       header: "RAG Supported",
       sortingField: "ragSupported",
-      cell: (item: ModelItem) => item.ragSupported != undefined ? (item.ragSupported ? "Yes" : "No") : "",
+      cell: (item: ModelItem) =>
+        item.ragSupported != undefined
+          ? item.ragSupported
+            ? "Yes"
+            : "No"
+          : "",
     },
     {
       id: "inputModalities",
       header: "Input modalities",
       sortingField: "inputModalities",
-      cell: (item: ModelItem) => item.inputModalities ? item.inputModalities.join(", ") : "",
+      cell: (item: ModelItem) =>
+        item.inputModalities ? item.inputModalities.join(", ") : "",
     },
     {
       id: "outputModalities",
       header: "Output modalities",
       sortingField: "outputModalities",
-      cell: (item: ModelItem) => item.outputModalities ? item.outputModalities.join(", ") : "",
+      cell: (item: ModelItem) =>
+        item.outputModalities ? item.outputModalities.join(", ") : "",
     },
     {
       id: "streaming",
       header: "Streaming",
       sortingField: "streaming",
-      cell: (item: ModelItem) => item.streaming != undefined ? (item.streaming ? "Yes" : "No") : "",
+      cell: (item: ModelItem) => (item.streaming ? "Yes" : "No"),
     },
     {
-      id: "availability",
-      header: "Model Availability",
-      sortingField: "availability",
-      cell: (item: ModelItem) => item.provider != "servicecatalog" ? <>Available</> : <>Deployable!</>,
-    }
+      id: "deployment",
+      header: "Hosted Deployment",
+      cell: (item: ModelItem) =>
+        item.deployed == undefined ? (
+          <Badge color="grey">N/A</Badge>
+        ) : item.deployed ? (
+          <Badge color="green">Model Deployed</Badge>
+        ) : (
+          <Badge color="blue">Model Not Deployed</Badge>
+        ),
+    },
   ];
 
 export const ModelsColumnFilteringProperties: PropertyFilterProperty[] = [

--- a/lib/user-interface/react-app/src/pages/chatbot/models/models.tsx
+++ b/lib/user-interface/react-app/src/pages/chatbot/models/models.tsx
@@ -1,8 +1,10 @@
 import {
   BreadcrumbGroup,
+  ButtonDropdown,
   Header,
   Pagination,
   PropertyFilter,
+  SpaceBetween,
   Table,
 } from "@cloudscape-design/components";
 import useOnFollow from "../../../common/hooks/use-on-follow";
@@ -27,6 +29,7 @@ export default function Models() {
   const appContext = useContext(AppContext);
   const [models, setModels] = useState<ModelItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [selectedItems, setSelectedItems] = useState<ModelItem[]>([]);
   const {
     items,
     actions,
@@ -100,7 +103,57 @@ export default function Models() {
           variant="full-page"
           stickyHeader={true}
           resizableColumns={true}
-          header={<Header variant="awsui-h1-sticky">Models</Header>}
+          onSelectionChange={({ detail }) =>
+            setSelectedItems(detail.selectedItems)
+          }
+          selectedItems={selectedItems}
+          trackBy="name"
+          selectionType="single"
+          isItemDisabled={(item) => item.deployed == undefined}
+          header={
+            <Header
+              actions={
+                <SpaceBetween direction="horizontal" size="xs">
+                  <ButtonDropdown
+                    disabled={selectedItems.length == 0}
+                    items={[
+                      {
+                        text: "Deploy Model",
+                        id: "deploy",
+                        disabled:
+                          selectedItems.length > 0
+                            ? selectedItems[0].deployed
+                            : true,
+                        disabledReason: "Selected model is already deployed.",
+                      },
+                      {
+                        text: "Delete Model",
+                        id: "delete",
+                        disabled:
+                          selectedItems.length > 0
+                            ? !selectedItems[0].deployed
+                            : true,
+                        disabledReason: "Selected model is not deployed.",
+                      },
+                      {
+                        text: "Deployment Details",
+                        id: "details",
+                      },
+                    ]}
+                  >
+                    Actions
+                  </ButtonDropdown>
+                </SpaceBetween>
+              }
+              variant="awsui-h1-sticky"
+              description="View the details of the variable LLM Models available for the Chatbot.
+            Bedrock models are fully managed and don't require resource deployments. 
+            SageMaker models are self-hosted. To deploy, stop or get details on a self-hosted model, 
+            select the model from the table and chose an action from the 'Actions' dropdown."
+            >
+              Models
+            </Header>
+          }
           loading={loading}
           loadingText="Loading Models"
           filter={


### PR DESCRIPTION
This change is to address #165 

**This change is still in development. PR documentation to be added before completion**

The goal in this change is to enable SageMaker endpoints to be auto-removed and user-requested/initiated to help reduce On-Demand spend. 
High-level, this change moves the SageMaker model endpoints to be defined in Service Catalog products. 
The user will be able to launch the various models from service catalog through the Chatbot models UI.
A cloudwatch alarm will be deployed to monitor invocations and alarm if there's no usage, trigger a resource deletion. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
