### PR TITLE
fix(genai_core): Added handling for bad FMs

### DIFF
--- a/lib/shared/layers/python-sdk/python/genai_core/models.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/models.py
@@ -70,8 +70,10 @@ def list_bedrock_models():
             }
             for model in bedrock_models
             # Exclude embeddings and stable diffusion models
-            if Modality.EMBEDDING.value not in model["outputModalities"]
-            and Modality.IMAGE.value not in model["outputModalities"]
+            if model.get("inputModalities", None) != None
+            and model.get("outputModalities", None) != None
+            and Modality.EMBEDDING.value not in model.get("outputModalities", [])
+            and Modality.IMAGE.value not in model.get("outputModalities", [])
         ]
 
         return models
@@ -101,13 +103,15 @@ def list_bedrock_finetuned_models():
             }
             for model in bedrock_custom_models
             # Exclude embeddings and stable diffusion models
-            if Modality.EMBEDDING.value not in model["outputModalities"]
-            and Modality.IMAGE.value not in model["outputModalities"]
+            if model.get("inputModalities", None) != None
+            and model.get("outputModalities", None) != None
+            and Modality.EMBEDDING.value not in model.get("outputModalities", [])
+            and Modality.IMAGE.value not in model.get("outputModalities", [])
         ]
 
         return models
     except Exception as e:
-        print(f"Error listing Bedrock models: {e}")
+        print(f"Error listing fine-tuned Bedrock models: {e}")
         return None
 
 

--- a/lib/shared/layers/python-sdk/python/genai_core/models.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/models.py
@@ -70,8 +70,8 @@ def list_bedrock_models():
             }
             for model in bedrock_models
             # Exclude embeddings and stable diffusion models
-            if model.get("inputModalities", None) != None
-            and model.get("outputModalities", None) != None
+            if "inputModalities" in model
+            and "outputModalities" in model
             and Modality.EMBEDDING.value not in model.get("outputModalities", [])
             and Modality.IMAGE.value not in model.get("outputModalities", [])
         ]

--- a/lib/shared/layers/python-sdk/python/genai_core/models.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/models.py
@@ -103,8 +103,8 @@ def list_bedrock_finetuned_models():
             }
             for model in bedrock_custom_models
             # Exclude embeddings and stable diffusion models
-            if model.get("inputModalities", None) != None
-            and model.get("outputModalities", None) != None
+            if "inputModalities" in model
+            and "outputModalities" in model
             and Modality.EMBEDDING.value not in model.get("outputModalities", [])
             and Modality.IMAGE.value not in model.get("outputModalities", [])
         ]


### PR DESCRIPTION
Bedrock can return FMs that are not valid, such as `foundation-model/amazon.dummy-model`



*Description of changes:*
Currently, when calling list models in boto3 for bedrock, there is an exception caused if the list of models returns invalid models. 
An example of a bad model in the list of models:
`{'modelArn': 'arn:aws:bedrock:us-west-2::foundation-model/amazon.dummy-model', 'modelId': 'amazon.dummy-model', 'inferenceTypesSupported': ['ON_DEMAND']
    }`

Since this model has no `inputModalities` or `outputModalities` it raises an exception and returns no models back. 

This change adds checks for `inputModalities` and `outputModalities` being present in the model details and skips the model if it's invalid. 

This change has been applied to both the `list_bedrock_finetuned_models` & `list_bedrock_models`

A change was also `list_bedrock_finetuned_models` to change the raised exception to differentiate exceptions between `list_bedrock_models` and `list_bedrock_finetuned_models`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
