### PR TITLE
Fix error with module not found for feedparser

### DIFF
--- a/lib/shared/file-import-batch-job/requirements.txt
+++ b/lib/shared/file-import-batch-job/requirements.txt
@@ -14,3 +14,4 @@ openai==0.28.0
 beautifulsoup4==4.12.2
 requests==2.31.0
 attrs==23.1.0
+feedparser==6.0.10


### PR DESCRIPTION
*Issue #, if available:*
There is no issue available.

*Description of changes:*
* Adding `feedparser==6.0.10` to the list of requirements for a task.
* It fixes the following error: `ModuleNotFoundError: No module named 'feedparser'`
* It happens when processing files for workspaces in the ECS docker image

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
