### PR TITLE
vpc endpoint subnets should be in different availability zones

### DIFF
--- a/lib/rag-engines/opensearch-vector/index.ts
+++ b/lib/rag-engines/opensearch-vector/index.ts
@@ -46,16 +46,16 @@ export class OpenSearchVector extends Construct {
     let seen = new Set<string>();
     const cfnVpcEndpoint = new oss.CfnVpcEndpoint(this, "VpcEndpoint", {
       name: Utils.getName(props.config, "genaichatbot-vpce"),
-      subnetIds: props.shared.vpc.filter(obj => {
-        if (seen.has(obj.availabilityZone)) {
+      subnetIds: props.shared.vpc
+        .filter((obj) => {
+          if (seen.has(obj.availabilityZone)) {
             return false;
-        } else {
+          } else {
             seen.add(obj.availabilityZone);
             return true;
-        }
-      }).privateSubnets.map(
-        (subnet) => subnet.subnetId
-      ),
+          }
+        })
+        .privateSubnets.map((subnet) => subnet.subnetId),
       vpcId: props.shared.vpc.vpcId,
       securityGroupIds: [sg.securityGroupId],
     });

--- a/lib/rag-engines/opensearch-vector/index.ts
+++ b/lib/rag-engines/opensearch-vector/index.ts
@@ -42,9 +42,18 @@ export class OpenSearchVector extends Construct {
       ec2.Port.tcp(443)
     );
 
+    // Make sure the subnets are not in the same availability zone.
+    let seen = new Set<string>();
     const cfnVpcEndpoint = new oss.CfnVpcEndpoint(this, "VpcEndpoint", {
       name: Utils.getName(props.config, "genaichatbot-vpce"),
-      subnetIds: props.shared.vpc.privateSubnets.map(
+      subnetIds: props.shared.vpc.filter(obj => {
+        if (seen.has(obj.availabilityZone)) {
+            return false;
+        } else {
+            seen.add(obj.availabilityZone);
+            return true;
+        }
+      }).privateSubnets.map(
         (subnet) => subnet.subnetId
       ),
       vpcId: props.shared.vpc.vpcId,


### PR DESCRIPTION
*Issue #, if available:*

VPC endpoint creation for open search fails if subnets are in the same availabilty zone. 

*Description of changes:*

Check if selected subnets have different availability zones.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
