### PR TITLE
fix(crawler): only process "text/html" Content-Type pages

### DIFF
--- a/lib/shared/layers/python-sdk/python/genai_core/websites/crawler.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/websites/crawler.py
@@ -101,6 +101,8 @@ def parse_url(url: str):
     base_url = f"{root_url_parse.scheme}://{root_url_parse.netloc}"
 
     response = requests.get(url, timeout=20)
+    if response.headers["Content-Type"] != "text/html":
+        raise Exception(f"Invalid content type {response.headers['Content-Type']}")
     soup = BeautifulSoup(response.content, "html.parser")
     content = soup.text
     content = re.sub(r"[ \n]+", " ", content)


### PR DESCRIPTION
*Issue #, if available:*

fix issue #209 

*Description of changes:*

Added a check on the `"Content-Type"` of the returned page and only process `"text/html"`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
