### PR TITLE
Feature: filter out Bedrock models that cannot be used in the playground

### DIFF
--- a/lib/shared/layers/common/requirements.txt
+++ b/lib/shared/layers/common/requirements.txt
@@ -1,5 +1,5 @@
 aws_xray_sdk==2.12.1
-boto3==1.28.68
+boto3==1.34.1
 numpy==1.26.0
 cfnresponse==1.1.2
 aws_requests_auth==0.4.3

--- a/lib/shared/layers/python-sdk/python/genai_core/models.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/models.py
@@ -55,8 +55,14 @@ def list_bedrock_models():
         if not bedrock:
             return None
 
-        response = bedrock.list_foundation_models()
-        bedrock_models = response.get("modelSummaries", [])
+        response = bedrock.list_foundation_models(
+            byInferenceType="ON_DEMAND", byOutputModality="TEXT"
+        )
+        bedrock_models = [
+            m
+            for m in response.get("modelSummaries", [])
+            if m.get("modelLifecycle", {}).get("status") == "ACTIVE"
+        ]
 
         models = [
             {

--- a/lib/shared/layers/python-sdk/python/genai_core/models.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/models.py
@@ -56,12 +56,14 @@ def list_bedrock_models():
             return None
 
         response = bedrock.list_foundation_models(
-            byInferenceType="ON_DEMAND", byOutputModality="TEXT"
+            byInferenceType=genai_core.types.InferenceType.ON_DEMAND.value,
+            byOutputModality=genai_core.types.Modality.TEXT.value,
         )
         bedrock_models = [
             m
             for m in response.get("modelSummaries", [])
-            if m.get("modelLifecycle", {}).get("status") == "ACTIVE"
+            if m.get("modelLifecycle", {}).get("status")
+            == genai_core.types.ModelStatus.ACTIVE.value
         ]
 
         models = [

--- a/lib/shared/layers/python-sdk/python/genai_core/types.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/types.py
@@ -39,6 +39,16 @@ class Modality(Enum):
     EMBEDDING = "EMBEDDING"
 
 
+class InferenceType(Enum):
+    ON_DEMAND = "ON_DEMAND"
+    PROVISIONED = "PROVISIONED"
+
+
+class ModelStatus(Enum):
+    ACTIVE = "ACTIVE"
+    LEGACY = "LEGACY"
+
+
 class ModelInterface(Enum):
     LANGCHIAN = "langchain"
     IDEFICS = "idefics"


### PR DESCRIPTION
*Issue #, if available:*

resolves: #267 

*Description of changes:*
Only retrieve ON_DEMAND inference models that support TEXT output when listing foundation models, and filters out those that are not marked as ACTIVE. For this to work `boto3` was updated to latest version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
