### PR TITLE
fix(opensearch-vector): updates the name of the Workspace/workflow for the OpenSearcherveless sample

### DIFF
--- a/lib/rag-engines/opensearch-vector/index.ts
+++ b/lib/rag-engines/opensearch-vector/index.ts
@@ -101,7 +101,7 @@ export class OpenSearchVector extends Construct {
 
     const createWorkflow = new CreateOpenSearchWorkspace(
       this,
-      "CreateAuroraWorkspace",
+      "CreateOpenSearchWorkspace",
       {
         config: props.config,
         shared: props.shared,


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
Minor change to update the id of the `CreateOpenSearchWorkspace` construct created in the `rag-engines/opensearch-vector` Opensearch vector store.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
