### PR TITLE
Use selectSubnets() instead of filter to ensure only one subnet per AZ

### DIFF
--- a/lib/rag-engines/opensearch-vector/index.ts
+++ b/lib/rag-engines/opensearch-vector/index.ts
@@ -45,7 +45,7 @@ export class OpenSearchVector extends Construct {
     const cfnVpcEndpoint = new oss.CfnVpcEndpoint(this, "VpcEndpoint", {
       name: Utils.getName(props.config, "genaichatbot-vpce"),
       // Make sure the subnets are not in the same availability zone.
-      subnetIds: props.shared.vpc.selectSubnets({onePerAz: true}).subnetIds,
+      subnetIds: props.shared.vpc.selectSubnets({onePerAz: true, subnetType: ec2.SubnetType.PRIVATE_ISOLATED}).subnetIds,
       vpcId: props.shared.vpc.vpcId,
       securityGroupIds: [sg.securityGroupId],
     });

--- a/lib/rag-engines/opensearch-vector/index.ts
+++ b/lib/rag-engines/opensearch-vector/index.ts
@@ -42,20 +42,10 @@ export class OpenSearchVector extends Construct {
       ec2.Port.tcp(443)
     );
 
-    // Make sure the subnets are not in the same availability zone.
-    let seen = new Set<string>();
     const cfnVpcEndpoint = new oss.CfnVpcEndpoint(this, "VpcEndpoint", {
       name: Utils.getName(props.config, "genaichatbot-vpce"),
-      subnetIds: props.shared.vpc
-        .filter((obj) => {
-          if (seen.has(obj.availabilityZone)) {
-            return false;
-          } else {
-            seen.add(obj.availabilityZone);
-            return true;
-          }
-        })
-        .privateSubnets.map((subnet) => subnet.subnetId),
+      // Make sure the subnets are not in the same availability zone.
+      subnetIds: props.shared.vpc.selectSubnets({onePerAz: true}).subnetIds,
       vpcId: props.shared.vpc.vpcId,
       securityGroupIds: [sg.securityGroupId],
     });


### PR DESCRIPTION
*Issue #, if available:* #296

*Description of changes:* Use selectSubnets() instead of filter to ensure only one subnet per AZ. The previous implementation (see #257) seems to have broken the build.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
