### PR TITLE
added setup CLI option for Kendra Enterprise

### DIFF
--- a/cli/magic-create.ts
+++ b/cli/magic-create.ts
@@ -79,6 +79,7 @@ const embeddingModels = [
         (m: any) => m.default
       )[0].name;
       options.kendraExternal = config.rag.engines.kendra.external;
+      options.kendraEnterprise = config.rag.engines.kendra.enterprise;
     }
     try {
       await processCreateOptions(options);
@@ -208,6 +209,17 @@ async function processCreateOptions(options: any): Promise<void> {
         return !(this as any).state.answers.enableRag;
       },
     },
+    {
+      type: "confirm",
+      name: "kendraEnterprise",
+      message: "Do you want to enable Kendra Enterprise Edition?",
+      initial:
+        options.kendraEnterprise ||
+        false,
+      skip(): boolean {
+        return !(this as any).state.answers.ragsToEnable.includes("kendra");
+      },
+    },
   ];
   const answers: any = await enquirer.prompt(questions);
   console.log(answers);
@@ -324,6 +336,7 @@ async function processCreateOptions(options: any): Promise<void> {
           enabled: false,
           createIndex: false,
           external: [{}],
+          enterprise: false
         },
       },
       embeddingsModels: [{}],
@@ -353,6 +366,8 @@ async function processCreateOptions(options: any): Promise<void> {
   config.rag.engines.kendra.enabled =
     config.rag.engines.kendra.createIndex || kendraExternal.length > 0;
   config.rag.engines.kendra.external = [...kendraExternal];
+  config.rag.engines.kendra.enterprise =
+    answers.kendraEnterprise
 
   console.log("\n✨ This is the chosen configuration:\n");
   console.log(JSON.stringify(config, undefined, 2));

--- a/lib/rag-engines/kendra-retrieval/index.ts
+++ b/lib/rag-engines/kendra-retrieval/index.ts
@@ -58,7 +58,7 @@ export class KendraRetrieval extends Construct {
       dataBucket.grantRead(kendraRole);
 
       const kendraIndex = new kendra.CfnIndex(this, "Index", {
-        edition: "DEVELOPER_EDITION",
+        edition: props.config.rag?.engines.kendra?.enterprise ? "ENTERPRISE_EDITION" : "DEVELOPER_EDITION",
         name: indexName,
         roleArn: kendraRole.roleArn,
         documentMetadataConfigurations: [

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -90,6 +90,7 @@ export interface SystemConfig {
           region?: SupportedRegion;
           roleArn?: string;
         }[];
+        enterprise?: boolean;
       };
     };
     embeddingsModels: {


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-samples/aws-genai-llm-chatbot/issues/300

Description of changes:
Allows customers to select their edition of Kendra upfront. Having the option upfront is important because it can be a large and cumbersome process to change from the Developer to Enterprise Edition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.