### PR TITLE
feat: enable/disable use of history in chat context

### DIFF
--- a/lib/chatbot-api/functions/api-handler/routes/workspaces.py
+++ b/lib/chatbot-api/functions/api-handler/routes/workspaces.py
@@ -32,6 +32,7 @@ class CreateWorkspaceAuroraRequest(BaseModel):
     chunkingStrategy: str
     chunkSize: int
     chunkOverlap: int
+    enableChatHistory: bool
 
 
 class CreateWorkspaceOpenSearchRequest(BaseModel):
@@ -46,6 +47,7 @@ class CreateWorkspaceOpenSearchRequest(BaseModel):
     chunkingStrategy: str
     chunkSize: int
     chunkOverlap: int
+    enableChatHistory: bool
 
 
 class CreateWorkspaceKendraRequest(BaseModel):
@@ -53,6 +55,7 @@ class CreateWorkspaceKendraRequest(BaseModel):
     name: str
     kendraIndexId: str
     useAllData: bool
+    enableChatHistory: bool
 
 
 @router.resolver(field_name="listWorkspaces")
@@ -185,6 +188,7 @@ def _create_workspace_aurora(request: CreateWorkspaceAuroraRequest, config: dict
             chunking_strategy=request.chunkingStrategy,
             chunk_size=request.chunkSize,
             chunk_overlap=request.chunkOverlap,
+            enable_chat_history=request.enableChatHistory,
         )
     )
 
@@ -256,6 +260,7 @@ def _create_workspace_open_search(
             chunking_strategy=request.chunkingStrategy,
             chunk_size=request.chunkSize,
             chunk_overlap=request.chunkOverlap,
+            enable_chat_history=request.enableChatHistory,
         )
     )
 
@@ -287,12 +292,14 @@ def _create_workspace_kendra(request: CreateWorkspaceKendraRequest, config: dict
             workspace_name=workspace_name,
             kendra_index=kendra_index,
             use_all_data=request.useAllData,
+            enable_chat_history=request.enableChatHistory,
         )
     )
 
 
 def _convert_workspace(workspace: dict):
     kendra_index_external = workspace.get("kendra_index_external")
+    enable_chat_history = workspace.get("enable_chat_history")
 
     return {
         "id": workspace["workspace_id"],
@@ -320,6 +327,7 @@ def _convert_workspace(workspace: dict):
         "kendraIndexId": workspace.get("kendra_index_id"),
         "kendraIndexExternal": kendra_index_external,
         "kendraUseAllData": workspace.get("kendra_use_all_data", kendra_index_external),
+        "enableChatHistory": workspace.get("enable_chat_history", enable_chat_history),
         "createdAt": workspace.get("created_at"),
         "updatedAt": workspace.get("updated_at"),
     }

--- a/lib/chatbot-api/schema/schema.graphql
+++ b/lib/chatbot-api/schema/schema.graphql
@@ -14,6 +14,7 @@ input CreateWorkspaceAuroraInput {
   chunkingStrategy: String!
   chunkSize: Int!
   chunkOverlap: Int!
+  enableChatHistory: Boolean!
 }
 
 input CreateWorkspaceKendraInput {
@@ -21,6 +22,7 @@ input CreateWorkspaceKendraInput {
   kind: String!
   kendraIndexId: String!
   useAllData: Boolean!
+  enableChatHistory: Boolean!
 }
 
 input CreateWorkspaceOpenSearchInput {
@@ -35,6 +37,7 @@ input CreateWorkspaceOpenSearchInput {
   chunkingStrategy: String!
   chunkSize: Int!
   chunkOverlap: Int!
+  enableChatHistory: Boolean!
 }
 
 input CalculateEmbeddingsInput {
@@ -275,6 +278,7 @@ type Workspace @aws_cognito_user_pools {
   kendraIndexId: String
   kendraIndexExternal: Boolean
   kendraUseAllData: Boolean
+  enableChatHistory: Boolean
   createdAt: AWSDateTime!
   updatedAt: AWSDateTime!
 }

--- a/lib/shared/layers/python-sdk/python/genai_core/kendra/query.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/kendra/query.py
@@ -13,6 +13,7 @@ def query_workspace_kendra(
     kendra_index_id = workspace.get("kendra_index_id")
     kendra_index_external = workspace.get("kendra_index_external", True)
     kendra_use_all_data = workspace.get("kendra_use_all_data", False)
+    enable_chat_history = workspace.get("enable_chat_history", True)
 
     if not kendra_index_id:
         raise genai_core.types.CommonError(

--- a/lib/shared/layers/python-sdk/python/genai_core/workspaces.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/workspaces.py
@@ -102,6 +102,7 @@ def create_workspace_aurora(
     chunking_strategy: str,
     chunk_size: int,
     chunk_overlap: int,
+    enable_chat_history: bool,
 ):
     workspace_id = str(uuid.uuid4())
     timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
@@ -133,6 +134,7 @@ def create_workspace_aurora(
         "chunking_strategy": chunking_strategy,
         "chunk_size": chunk_size,
         "chunk_overlap": chunk_overlap,
+        "enable_chat_history": enable_chat_history,
         "documents": 0,
         "vectors": 0,
         "size_in_bytes": 0,
@@ -169,6 +171,7 @@ def create_workspace_open_search(
     chunking_strategy: str,
     chunk_size: int,
     chunk_overlap: int,
+    enable_chat_history: bool,
 ):
     workspace_id = str(uuid.uuid4())
     timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
@@ -200,6 +203,7 @@ def create_workspace_open_search(
         "chunking_strategy": chunking_strategy,
         "chunk_size": chunk_size,
         "chunk_overlap": chunk_overlap,
+        "enable_chat_history": enable_chat_history,
         "documents": 0,
         "vectors": 0,
         "size_in_bytes": 0,
@@ -225,7 +229,7 @@ def create_workspace_open_search(
 
 
 def create_workspace_kendra(
-    workspace_name: str, kendra_index: dict, use_all_data: bool
+    workspace_name: str, kendra_index: dict, use_all_data: bool, enable_chat_history: bool
 ):
     workspace_id = str(uuid.uuid4())
     timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
@@ -243,6 +247,7 @@ def create_workspace_kendra(
         "kendra_index_id": kendra_index_id,
         "kendra_index_external": kendra_index_external,
         "kendra_use_all_data": use_all_data,
+        "enable_chat_history": enable_chat_history,
         "documents": 0,
         "vectors": 0,
         "size_in_bytes": 0,

--- a/lib/user-interface/react-app/schema.json
+++ b/lib/user-interface/react-app/schema.json
@@ -980,6 +980,17 @@
           "isDeprecated" : false,
           "deprecationReason" : null
         }, {
+          "name" : "enableChatHistory",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Boolean",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
           "name" : "createdAt",
           "description" : null,
           "args" : [ ],
@@ -2894,6 +2905,19 @@
             }
           },
           "defaultValue" : null
+        }, {
+          "name" : "enableChatHistory",
+          "description" : null,
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Boolean",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
         } ],
         "interfaces" : null,
         "enumValues" : null,
@@ -3054,6 +3078,19 @@
             }
           },
           "defaultValue" : null
+        }, {
+          "name" : "enableChatHistory",
+          "description" : null,
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Boolean",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
         } ],
         "interfaces" : null,
         "enumValues" : null,
@@ -3137,6 +3174,19 @@
             "ofType" : {
               "kind" : "SCALAR",
               "name" : "String",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "enableChatHistory",
+          "description" : null,
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Boolean",
               "ofType" : null
             }
           },

--- a/lib/user-interface/react-app/src/API.ts
+++ b/lib/user-interface/react-app/src/API.ts
@@ -14,6 +14,7 @@ export type CreateWorkspaceKendraInput = {
   kind: string,
   kendraIndexId: string,
   useAllData: boolean,
+  enableChatHistory: boolean,
 };
 
 export type Workspace = {
@@ -43,6 +44,7 @@ export type Workspace = {
   kendraIndexId?: string | null,
   kendraIndexExternal?: string | null,
   kendraUseAllData?: boolean | null,
+  enableChatHistory?: boolean | null,
   createdAt: string,
   updatedAt: string,
 };
@@ -362,6 +364,7 @@ export type CreateKendraWorkspaceMutation = {
     kendraIndexId?: string | null,
     kendraIndexExternal?: string | null,
     kendraUseAllData?: boolean | null,
+    enableChatHistory?: boolean | null,
     createdAt: string,
     updatedAt: string,
   },
@@ -399,6 +402,7 @@ export type CreateOpenSearchWorkspaceMutation = {
     kendraIndexId?: string | null,
     kendraIndexExternal?: string | null,
     kendraUseAllData?: boolean | null,
+    enableChatHistory?: boolean | null,
     createdAt: string,
     updatedAt: string,
   },
@@ -436,6 +440,7 @@ export type CreateAuroraWorkspaceMutation = {
     kendraIndexId?: string | null,
     kendraIndexExternal?: string | null,
     kendraUseAllData?: boolean | null,
+    enableChatHistory?: boolean | null,
     createdAt: string,
     updatedAt: string,
   },
@@ -631,6 +636,7 @@ export type ListWorkspacesQuery = {
     kendraIndexId?: string | null,
     kendraIndexExternal?: string | null,
     kendraUseAllData?: boolean | null,
+    enableChatHistory?: boolean | null,
     createdAt: string,
     updatedAt: string,
   } >,
@@ -668,6 +674,7 @@ export type GetWorkspaceQuery = {
     kendraIndexId?: string | null,
     kendraIndexExternal?: string | null,
     kendraUseAllData?: boolean | null,
+    enableChatHistory?: boolean | null,
     createdAt: string,
     updatedAt: string,
   } | null,

--- a/lib/user-interface/react-app/src/common/api-client/workspaces-client.ts
+++ b/lib/user-interface/react-app/src/common/api-client/workspaces-client.ts
@@ -63,6 +63,7 @@ export class WorkspacesClient {
     chunkingStrategy: string;
     chunkSize: number;
     chunkOverlap: number;
+    enableChatHistory: boolean;
   }): Promise<GraphQLResult<GraphQLQuery<CreateAuroraWorkspaceMutation>>> {
     const result = API.graphql<GraphQLQuery<CreateAuroraWorkspaceMutation>>({
       query: createAuroraWorkspace,
@@ -84,6 +85,7 @@ export class WorkspacesClient {
     chunkingStrategy: string;
     chunkSize: number;
     chunkOverlap: number;
+    enableChatHistory: boolean;
   }): Promise<GraphQLResult<GraphQLQuery<CreateOpenSearchWorkspaceMutation>>> {
     const result = API.graphql<GraphQLQuery<CreateOpenSearchWorkspaceMutation>>(
       {
@@ -100,6 +102,7 @@ export class WorkspacesClient {
     name: string;
     kendraIndexId: string;
     useAllData: boolean;
+    enableChatHistory: boolean;
   }): Promise<GraphQLResult<GraphQLQuery<CreateKendraWorkspaceMutation>>> {
     const result = API.graphql<GraphQLQuery<CreateKendraWorkspaceMutation>>({
       query: createKendraWorkspace,

--- a/lib/user-interface/react-app/src/common/types.ts
+++ b/lib/user-interface/react-app/src/common/types.ts
@@ -70,6 +70,7 @@ export interface AuroraWorkspaceCreateInput {
   hybridSearch: boolean;
   chunkSize: number;
   chunkOverlap: number;
+  enableChatHistory: boolean;
 }
 
 export interface OpenSearchWorkspaceCreateInput {
@@ -80,10 +81,12 @@ export interface OpenSearchWorkspaceCreateInput {
   hybridSearch: boolean;
   chunkSize: number;
   chunkOverlap: number;
+  enableChatHistory: boolean;
 }
 
 export interface KendraWorkspaceCreateInput {
   name: string;
   kendraIndex: SelectProps.Option | null;
   useAllData: boolean;
+  enableChatHistory: boolean;
 }

--- a/lib/user-interface/react-app/src/graphql/mutations.ts
+++ b/lib/user-interface/react-app/src/graphql/mutations.ts
@@ -54,6 +54,7 @@ export const createKendraWorkspace = /* GraphQL */ `mutation CreateKendraWorkspa
     kendraIndexId
     kendraIndexExternal
     kendraUseAllData
+    enableChatHistory
     createdAt
     updatedAt
     __typename
@@ -90,6 +91,7 @@ export const createOpenSearchWorkspace = /* GraphQL */ `mutation CreateOpenSearc
     kendraIndexId
     kendraIndexExternal
     kendraUseAllData
+    enableChatHistory
     createdAt
     updatedAt
     __typename
@@ -126,6 +128,7 @@ export const createAuroraWorkspace = /* GraphQL */ `mutation CreateAuroraWorkspa
     kendraIndexId
     kendraIndexExternal
     kendraUseAllData
+    enableChatHistory
     createdAt
     updatedAt
     __typename

--- a/lib/user-interface/react-app/src/graphql/queries.ts
+++ b/lib/user-interface/react-app/src/graphql/queries.ts
@@ -73,6 +73,7 @@ export const listWorkspaces = /* GraphQL */ `query ListWorkspaces {
     kendraIndexId
     kendraIndexExternal
     kendraUseAllData
+    enableChatHistory
     createdAt
     updatedAt
     __typename
@@ -109,6 +110,7 @@ export const getWorkspace = /* GraphQL */ `query GetWorkspace($workspaceId: Stri
     kendraIndexId
     kendraIndexExternal
     kendraUseAllData
+    enableChatHistory
     createdAt
     updatedAt
     __typename

--- a/lib/user-interface/react-app/src/pages/rag/create-workspace/aurora-form.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/create-workspace/aurora-form.tsx
@@ -51,6 +51,21 @@ export default function AuroraForm(props: AuroraFormProps) {
             }
           />
         </FormField>
+        <FormField
+          label="Enable chat history context for this workspace"
+          description="By default, each chat window will use the previous chat history to form part of its next answer, disabling this setting still records the chat history but prevents it from being used as further context in the chat conversation."
+          errorText={props.errors.index}
+        >
+          <Toggle
+            disabled={props.submitting}
+            checked={props.data.enableChatHistory}
+            onChange={({ detail: { checked } }) =>
+              props.onChange({ enableChatHistory: checked })
+            }
+          >
+            Enable history context
+          </Toggle>
+        </FormField>
 
         <EmbeddingSelector
           errors={props.errors}

--- a/lib/user-interface/react-app/src/pages/rag/create-workspace/create-workspace-aurora.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/create-workspace/create-workspace-aurora.tsx
@@ -37,6 +37,7 @@ const defaults: AuroraWorkspaceCreateInput = {
   hybridSearch: true,
   chunkSize: 1000,
   chunkOverlap: 200,
+  enableChatHistory: true,
 };
 
 export default function CreateWorkspaceAurora() {
@@ -147,6 +148,7 @@ export default function CreateWorkspaceAurora() {
         chunkingStrategy: "recursive",
         chunkSize: data.chunkSize,
         chunkOverlap: data.chunkOverlap,
+        enableChatHistory: data.enableChatHistory,
       });
 
       navigate(`/rag/workspaces/${result.data?.createAuroraWorkspace.id}`);

--- a/lib/user-interface/react-app/src/pages/rag/create-workspace/create-workspace-kendra.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/create-workspace/create-workspace-kendra.tsx
@@ -14,6 +14,7 @@ const defaults: KendraWorkspaceCreateInput = {
   name: "",
   kendraIndex: null,
   useAllData: false,
+  enableChatHistory: true,
 };
 
 export default function CreateWorkspaceKendra() {
@@ -63,6 +64,7 @@ export default function CreateWorkspaceKendra() {
         name: data.name.trim(),
         kendraIndexId: data.kendraIndex?.value ?? "",
         useAllData: data.useAllData,
+        enableChatHistory: data.enableChatHistory,
       });
 
       navigate("/rag/workspaces");

--- a/lib/user-interface/react-app/src/pages/rag/create-workspace/create-workspace-opensearch.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/create-workspace/create-workspace-opensearch.tsx
@@ -20,6 +20,7 @@ const defaults: OpenSearchWorkspaceCreateInput = {
   hybridSearch: true,
   chunkSize: 1000,
   chunkOverlap: 200,
+  enableChatHistory: true,
 };
 
 export default function CreateWorkspaceOpenSearch() {
@@ -117,6 +118,7 @@ export default function CreateWorkspaceOpenSearch() {
         chunkingStrategy: "recursive",
         chunkSize: data.chunkSize,
         chunkOverlap: data.chunkOverlap,
+        enableChatHistory: data.enableChatHistory,
       });
 
       navigate("/rag/workspaces");

--- a/lib/user-interface/react-app/src/pages/rag/create-workspace/kendra-form.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/create-workspace/kendra-form.tsx
@@ -111,6 +111,21 @@ export default function KendraForm(props: KendraFormProps) {
             Use all data
           </Toggle>
         </FormField>
+        <FormField
+          label="Enable chat history context for this workspace"
+          description="By default, each chat window will use the previous chat history to form part of its next answer, disabling this setting still records the chat history but prevents it from being used as further context in the chat conversation."
+          errorText={props.errors.index}
+        >
+          <Toggle
+            disabled={props.submitting}
+            checked={props.data.enableChatHistory}
+            onChange={({ detail: { checked } }) =>
+              props.onChange({ enableChatHistory: checked })
+            }
+          >
+            Enable history context
+          </Toggle>
+        </FormField>
       </SpaceBetween>
     </Container>
   );

--- a/lib/user-interface/react-app/src/pages/rag/create-workspace/opensearch-form.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/create-workspace/opensearch-form.tsx
@@ -6,6 +6,7 @@ import {
   FormField,
   Input,
   ExpandableSection,
+  Toggle,
 } from "@cloudscape-design/components";
 import EmbeddingSelector from "./embeddings-selector-field";
 import { CrossEncoderSelectorField } from "./cross-encoder-selector-field";
@@ -43,6 +44,21 @@ export function OpenSearchForm(props: OpenSearchFormProps) {
               props.onChange({ name: value })
             }
           />
+        </FormField>
+        <FormField
+          label="Enable chat history context for this workspace"
+          description="By default, each chat window will use the previous chat history to form part of its next answer, disabling this setting still records the chat history but prevents it from being used as further context in the chat conversation."
+          errorText={props.errors.index}
+        >
+          <Toggle
+            disabled={props.submitting}
+            checked={props.data.enableChatHistory}
+            onChange={({ detail: { checked } }) =>
+              props.onChange({ enableChatHistory: checked })
+            }
+          >
+            Enable history context
+          </Toggle>
         </FormField>
         <EmbeddingSelector
           submitting={props.submitting}

--- a/lib/user-interface/react-app/src/pages/rag/workspace/aurora-workspace-settings.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/workspace/aurora-workspace-settings.tsx
@@ -100,6 +100,10 @@ export default function AuroraWorkspaceSettings(
             <Box variant="awsui-key-label">Chunk overlap</Box>
             <div>{props.workspace.chunkOverlap}</div>
           </div>
+          <div>
+            <Box variant="awsui-key-label">Enable Chat History</Box>
+            <div>{props.workspace.enableChatHistory ? "Yes" : "No"}</div>
+          </div>
         </SpaceBetween>
       </ColumnLayout>
     </Container>

--- a/lib/user-interface/react-app/src/pages/rag/workspace/kendra-workspace-settings.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/workspace/kendra-workspace-settings.tsx
@@ -137,6 +137,12 @@ export default function KendraWorkspaceSettings(
                   <div>{props.workspace.kendraUseAllData ? "Yes" : "No"}</div>
                 </div>
               )}
+              {typeof props.workspace.enableChatHistory !== "undefined" && (
+                <div>
+                  <Box variant="awsui-key-label">Enable Chat History</Box>
+                  <div>{props.workspace.enableChatHistory ? "Yes" : "No"}</div>
+                </div>
+              )}
             </SpaceBetween>
           </ColumnLayout>
         </Container>

--- a/lib/user-interface/react-app/src/pages/rag/workspace/open-search-workspace-settings.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/workspace/open-search-workspace-settings.tsx
@@ -94,6 +94,10 @@ export default function OpenSearchWorkspaceSettings(
             <Box variant="awsui-key-label">Chunk overlap</Box>
             <div>{props.workspace.chunkOverlap}</div>
           </div>
+          <div>
+            <Box variant="awsui-key-label">Enable Chat History</Box>
+            <div>{props.workspace.enableChatHistory ? "Yes" : "No"}</div>
+          </div>
         </SpaceBetween>
       </ColumnLayout>
     </Container>


### PR DESCRIPTION

*Issue #, if available:* #306

*Description of changes:*
Allows customers to disable chat history context usage without affecting the recording of chat history for logging purposes. This setting is implemented on a per workspace level.

The updated UI elements on the create workspace workflow further explain the setting to the users and it is enabled by default to retain existing functionality.

I have tested the changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
