### PR TITLE
fix: update broken links on docs homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ hero:
   actions:
     - theme: brand
       text: Guide
-      link: /guide/getting-started
+      link: /guide/deploy
     - theme: alt
       text: View on GitHub
       link: https://github.com/aws-samples/aws-genai-llm-chatbot


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix broken link on VitePress docs homepage (link: https://aws-samples.github.io/aws-genai-llm-chatbot/)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
