### PR TITLE
feat: installer display instance size used next to model name for sagemaker

### DIFF
--- a/cli/magic-create.ts
+++ b/cli/magic-create.ts
@@ -155,7 +155,7 @@ async function processCreateOptions(options: any): Promise<void> {
     {
       type: "multiselect",
       name: "sagemakerModels",
-      hint: "SPACE to select, ENTER to confirm selection",
+      hint: "SPACE to select, ENTER to confirm selection [denotes instance size to host model]",
       message: "Which SageMaker Models do you want to enable",
       choices: Object.values(SupportedSageMakerModels),
       initial:

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -3,13 +3,13 @@ import * as sagemaker from "aws-cdk-lib/aws-sagemaker";
 export type ModelProvider = "sagemaker" | "bedrock" | "openai";
 
 export enum SupportedSageMakerModels {
-  FalconLite = "FalconLite",
-  Llama2_13b_Chat = "Llama2_13b_Chat",
-  Mistral7b_Instruct = "Mistral7b_Instruct 0.1",
-  Mistral7b_Instruct2 = "Mistral7b_Instruct 0.2",
-  Mixtral_8x7b_Instruct = "Mixtral-8x7B Instruct 0.1",
-  Idefics_9b = "Idefics_9b (Multimodal)",
-  Idefics_80b = "Idefics_80b (Multimodal)",
+  FalconLite = "FalconLite [ml.g5.12xlarge]",
+  Llama2_13b_Chat = "Llama2_13b_Chat [ml.g5.12xlarge]",
+  Mistral7b_Instruct = "Mistral7b_Instruct 0.1 [ml.g5.2xlarge]",
+  Mistral7b_Instruct2 = "Mistral7b_Instruct 0.2 [ml.g5.2xlarge]",
+  Mixtral_8x7b_Instruct = "Mixtral_8x7B_Instruct 0.1 [ml.g5.48xlarge]",
+  Idefics_9b = "Idefics_9b (Multimodal) [ml.g5.12xlarge]",
+  Idefics_80b = "Idefics_80b (Multimodal) [ml.g5.48xlarge]",
 }
 
 export enum SupportedRegion {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
During the installer when selecting sagemaker models, annotated the model names with [] denoting the instance type deployed, this helps inform users about the different model options associated efficiencies and allows them to look up costs that are relevant.

Some other small formatting changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
