### PR TITLE
docs: change docs link to button to make it clearer to users

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Deploy with GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://aws-samples.github.io/aws-genai-llm-chatbot/guide/deploy.html#deploy-with-github-codespaces)
 
-#### [Full documentation](https://aws-samples.github.io/aws-genai-llm-chatbot/)
+[![Full Documentation](https://img.shields.io/badge/Full%20Documentation-blue?style=for-the-badge&logo=Vite&logoColor=white)](https://aws-samples.github.io/aws-genai-llm-chatbot/)
 
 ![sample](docs/about/assets/chabot-sample.gif "AWS GenAI Chatbot")
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The link to the VitePress docs site in the README is not very visible to users. This PR changes the link to a button for better visibility. 
Button appearance: https://github.com/dairiley/aws-genai-llm-chatbot/blob/convert_docs_link_to_button/README.md

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
