### PR TITLE
Fix duplicates when starting multiple sessions for the same user

### DIFF
--- a/cli/magic-create.ts
+++ b/cli/magic-create.ts
@@ -248,7 +248,7 @@ async function processCreateOptions(options: any): Promise<void> {
     },
   ];
   const answers: any = await enquirer.prompt(questions);
-  const kendraExternal = [];
+  const kendraExternal: any[] = [];
   let newKendra = answers.enableRag && answers.kendra;
   const existingKendraIndices = Array.from(options.kendraExternal || []);
   while (newKendra === true) {

--- a/lib/chatbot-api/functions/resolvers/subscribe-resolver.js
+++ b/lib/chatbot-api/functions/resolvers/subscribe-resolver.js
@@ -7,7 +7,12 @@ export function request(ctx) {
 }
 
 export function response(ctx) {
-  const filter = { and: [{ userId: { eq: ctx.identity.sub } }] };
+  const filter = {
+    and: [
+      { userId: { eq: ctx.identity.sub } },
+      { sessionId: { eq: ctx.args.sessionId } },
+    ],
+  };
   extensions.setSubscriptionFilter(util.transform.toSubscriptionFilter(filter));
   return null;
 }

--- a/lib/user-interface/react-app/src/components/chatbot/multi-chat.tsx
+++ b/lib/user-interface/react-app/src/components/chatbot/multi-chat.tsx
@@ -56,7 +56,7 @@ export interface ChatSession {
   loading: boolean;
   running: boolean;
   messageHistory: ChatBotHistoryItem[];
-  subscription?: Promise<ZenObservable.Subscription>;
+  subscription?: ZenObservable.Subscription;
 }
 
 function createNewSession(): ChatSession {
@@ -153,7 +153,7 @@ export default function MultiChat() {
     return () => {
       refChatSessions.current.forEach((session) => {
         console.log(`Unsubscribing from ${session.id}`);
-        session.subscription?.then((s) => s.unsubscribe());
+        session.subscription?.unsubscribe();
       });
       refChatSessions.current = [];
     };
@@ -226,11 +226,9 @@ export default function MultiChat() {
     });
   };
 
-  async function subscribe(sessionId: string) {
+  function subscribe(sessionId: string): ZenObservable.Subscription {
     console.log("Subscribing to AppSync");
-    const sub = await API.graphql<
-      GraphQLSubscription<ReceiveMessagesSubscription>
-    >({
+    const sub = API.graphql<GraphQLSubscription<ReceiveMessagesSubscription>>({
       query: receiveMessages,
       variables: {
         sessionId: sessionId,
@@ -241,7 +239,7 @@ export default function MultiChat() {
         const data = value.data!.receiveMessages?.data;
         if (data !== undefined && data !== null) {
           const response: ChatBotMessageResponse = JSON.parse(data);
-          console.log(response);
+          console.log(JSON.stringify(response));
           if (response.action === ChatBotAction.Heartbeat) {
             console.log("Heartbeat pong!");
             return;
@@ -275,33 +273,28 @@ export default function MultiChat() {
     }
 
     const session = createNewSession();
-
     const sub = subscribe(session.id);
-    sub
-      .then(() => {
-        console.log(`Subscribed to session ${session.id}}`);
-        const request: ChatBotHeartbeatRequest = {
-          action: ChatBotAction.Heartbeat,
-          modelInterface: ChatBotModelInterface.Langchain,
-          data: {
-            sessionId: session.id,
-          },
-        };
-        const result = API.graphql({
-          query: sendQuery,
-          variables: {
-            data: JSON.stringify(request),
-          },
-        });
-        console.log(result);
-      })
-      .catch((err) => {
-        console.log(err);
-      });
 
+    console.log(`Subscribed to session ${session.id}}`);
+    const request: ChatBotHeartbeatRequest = {
+      action: ChatBotAction.Heartbeat,
+      modelInterface: ChatBotModelInterface.Langchain,
+      data: {
+        sessionId: session.id,
+      },
+    };
+    API.graphql({
+      query: sendQuery,
+      variables: {
+        data: JSON.stringify(request),
+      },
+    });
     session.subscription = sub;
     refChatSessions.current.push(session);
-    console.log(refChatSessions);
+    console.log(
+      "Sessions",
+      refChatSessions.current.map((s) => s.id)
+    );
     setChatSessions([...refChatSessions.current]);
   }
 
@@ -369,7 +362,7 @@ export default function MultiChat() {
             <Button
               onClick={() => {
                 refChatSessions.current.forEach((s) => {
-                  s.subscription?.then((s) => s.unsubscribe());
+                  s.subscription?.unsubscribe();
                   s.messageHistory = [];
                   s.id = uuidv4();
                   s.subscription = subscribe(s.id);
@@ -432,10 +425,8 @@ export default function MultiChat() {
                       onClick={() => {
                         refChatSessions.current
                           .filter((c) => c.id == chatSession.id)[0]
-                          .subscription?.then((s) => {
-                            console.log(`Unsubscribe from ${chatSession.id}`);
-                            s.unsubscribe();
-                          });
+                          .subscription?.unsubscribe();
+                        console.log(`Unsubscribe from ${chatSession.id}`);
                         refChatSessions.current =
                           refChatSessions.current.filter(
                             (c) => c.id !== chatSession.id

--- a/lib/user-interface/react-app/src/components/chatbot/utils.ts
+++ b/lib/user-interface/react-app/src/components/chatbot/utils.ts
@@ -138,17 +138,7 @@ export function updateMessageHistoryRef(
       const lastMessage = messageHistory.at(-1)!;
       lastMessage.tokens = lastMessage.tokens ?? [];
       if (hasToken) {
-        // Workaround for text duplicates issue
-        if (
-          !lastMessage.tokens
-            .map((t) => t.sequenceNumber)
-            .includes(token.sequenceNumber)
-        ) {
-          lastMessage.tokens.push(token);
-        } else {
-          return;
-        }
-      } else {
+        lastMessage.tokens.push(token);
       }
 
       lastMessage.tokens.sort((a, b) => a.sequenceNumber - b.sequenceNumber);


### PR DESCRIPTION
*Issue #, if available:*

Fixes #341

*Description of changes:*
Added `sessionId` to the GraphQL advanced subscription filter.
Without advanced subscription the subscription `args` are used automatically for filtering messages, but when using advanced filtering it is necessary to specify it explicitly in the filter expression.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
