### PR TITLE
Fix #351. Lookup VPCe ENI based on service name instead of endpoint i…

### DIFF
--- a/lib/shared/index.ts
+++ b/lib/shared/index.ts
@@ -112,86 +112,87 @@ export class Shared extends Construct {
         service: ec2.InterfaceVpcEndpointAwsService.SAGEMAKER_RUNTIME,
         open: true,
       });
-      
-    }
-    
-    if (props.config.privateWebsite) {
-      // Create VPC Endpoint for AppSync
-      vpc.addInterfaceEndpoint("AppSyncEndpoint", {
-          service: ec2.InterfaceVpcEndpointAwsService.APP_SYNC,
-      });
-      
-      // Create VPC Endpoint for Lambda
-      vpc.addInterfaceEndpoint("LambdaEndpoint", {
-          service: ec2.InterfaceVpcEndpointAwsService.LAMBDA,
-      });
-      
-      // Create VPC Endpoint for SNS
-      vpc.addInterfaceEndpoint("SNSEndpoint", {
-          service: ec2.InterfaceVpcEndpointAwsService.SNS,
-      });
-      
-      // Create VPC Endpoint for Step Functions
-      vpc.addInterfaceEndpoint("StepFunctionsEndpoint", {
-          service: ec2.InterfaceVpcEndpointAwsService.STEP_FUNCTIONS,
-      });
-     
-      // Create VPC Endpoint for SSM
-      vpc.addInterfaceEndpoint("SSMEndpoint", {
-          service: ec2.InterfaceVpcEndpointAwsService.SSM,
-      });
-      
-      // Create VPC Endpoint for KMS
-      vpc.addInterfaceEndpoint("KMSEndpoint", {
-          service: ec2.InterfaceVpcEndpointAwsService.KMS,
-      });
-      
-      // Create VPC Endpoint for Bedrock
-      if (props.config.bedrock?.enabled && Object.values(SupportedBedrockRegion).some(val => val === cdk.Stack.of(this).region)){
-        vpc.addInterfaceEndpoint("BedrockEndpoint", {
-          service: new ec2.InterfaceVpcEndpointService('com.amazonaws.'+cdk.Aws.REGION+'.bedrock-runtime', 443),
-          privateDnsEnabled: true
+
+      if (props.config.privateWebsite) {
+        // Create VPC Endpoint for AppSync
+        vpc.addInterfaceEndpoint("AppSyncEndpoint", {
+            service: ec2.InterfaceVpcEndpointAwsService.APP_SYNC,
         });
+
+        // Create VPC Endpoint for Lambda
+        vpc.addInterfaceEndpoint("LambdaEndpoint", {
+            service: ec2.InterfaceVpcEndpointAwsService.LAMBDA,
+        });
+
+        // Create VPC Endpoint for SNS
+        vpc.addInterfaceEndpoint("SNSEndpoint", {
+            service: ec2.InterfaceVpcEndpointAwsService.SNS,
+        });
+
+        // Create VPC Endpoint for Step Functions
+        vpc.addInterfaceEndpoint("StepFunctionsEndpoint", {
+            service: ec2.InterfaceVpcEndpointAwsService.STEP_FUNCTIONS,
+        });
+
+        // Create VPC Endpoint for SSM
+        vpc.addInterfaceEndpoint("SSMEndpoint", {
+            service: ec2.InterfaceVpcEndpointAwsService.SSM,
+        });
+
+        // Create VPC Endpoint for KMS
+        vpc.addInterfaceEndpoint("KMSEndpoint", {
+            service: ec2.InterfaceVpcEndpointAwsService.KMS,
+        });
+
+        // Create VPC Endpoint for Bedrock
+        if (props.config.bedrock?.enabled && Object.values(SupportedBedrockRegion).some(val => val === cdk.Stack.of(this).region)){
+          if (props.config.bedrock?.region !== cdk.Stack.of(this).region) {
+            throw new Error(`Bedrock is only supported in the same region as the stack when using private website (Bedrock region: ${props.config.bedrock?.region}, Stack region: ${cdk.Stack.of(this).region}).`);
+          }
+          vpc.addInterfaceEndpoint("BedrockEndpoint", {
+            service: new ec2.InterfaceVpcEndpointService('com.amazonaws.'+cdk.Aws.REGION+'.bedrock-runtime', 443),
+            privateDnsEnabled: true
+          });
+        }
+
+        // Create VPC Endpoint for Kendra
+        if (props.config.rag.engines.kendra.enabled){
+          vpc.addInterfaceEndpoint("KendraEndpoint", {
+              service: ec2.InterfaceVpcEndpointAwsService.KENDRA,
+          });
+        }
+
+        // Create VPC Endpoint for RDS/Aurora
+        if (props.config.rag.engines.aurora.enabled) {
+          vpc.addInterfaceEndpoint("RDSEndpoint", {
+              service: ec2.InterfaceVpcEndpointAwsService.RDS,
+          });
+
+          // Create VPC Endpoint for RDS Data
+          vpc.addInterfaceEndpoint("RDSDataEndpoint", {
+              service: ec2.InterfaceVpcEndpointAwsService.RDS_DATA,
+          });
+        }
+
+        // Create VPC Endpoints needed for Aurora & Opensearch Indexing
+        if (props.config.rag.engines.aurora.enabled ||
+          props.config.rag.engines.opensearch.enabled) {
+          // Create VPC Endpoint for ECS
+          vpc.addInterfaceEndpoint("ECSEndpoint", {
+              service: ec2.InterfaceVpcEndpointAwsService.ECS,
+          });
+
+          // Create VPC Endpoint for Batch
+          vpc.addInterfaceEndpoint("BatchEndpoint", {
+              service: ec2.InterfaceVpcEndpointAwsService.BATCH,
+          });
+
+          // Create VPC Endpoint for EC2
+          vpc.addInterfaceEndpoint("EC2Endpoint", {
+              service: ec2.InterfaceVpcEndpointAwsService.EC2,
+          });
+        }
       }
-      
-      // Create VPC Endpoint for Kendra
-      if (props.config.rag.engines.kendra.enabled){
-        vpc.addInterfaceEndpoint("KendraEndpoint", {
-            service: ec2.InterfaceVpcEndpointAwsService.KENDRA,
-        });
-      }
-      
-      // Create VPC Endpoint for RDS/Aurora
-      if (props.config.rag.engines.aurora.enabled) {
-        vpc.addInterfaceEndpoint("RDSEndpoint", {
-            service: ec2.InterfaceVpcEndpointAwsService.RDS,
-        });
-        
-        // Create VPC Endpoint for RDS Data
-        vpc.addInterfaceEndpoint("RDSDataEndpoint", {
-            service: ec2.InterfaceVpcEndpointAwsService.RDS_DATA,
-        });
-      }
-      
-      // Create VPC Endpoints needed for Aurora & Opensearch Indexing
-      if (props.config.rag.engines.aurora.enabled ||
-        props.config.rag.engines.opensearch.enabled) {
-        // Create VPC Endpoint for ECS
-        vpc.addInterfaceEndpoint("ECSEndpoint", {
-            service: ec2.InterfaceVpcEndpointAwsService.ECS,
-        });
-        
-        // Create VPC Endpoint for Batch
-        vpc.addInterfaceEndpoint("BatchEndpoint", {
-            service: ec2.InterfaceVpcEndpointAwsService.BATCH,
-        });
-        
-        // Create VPC Endpoint for EC2
-        vpc.addInterfaceEndpoint("EC2Endpoint", {
-            service: ec2.InterfaceVpcEndpointAwsService.EC2,
-        });
-      }
-      
     }
 
     const configParameter = new ssm.StringParameter(this, "Config", {

--- a/lib/user-interface/private-website.ts
+++ b/lib/user-interface/private-website.ts
@@ -1,25 +1,14 @@
-import * as apigwv2 from "@aws-cdk/aws-apigatewayv2-alpha";
 import * as cognitoIdentityPool from "@aws-cdk/aws-cognito-identitypool-alpha";
 import * as cdk from "aws-cdk-lib";
-import * as apigateway from "aws-cdk-lib/aws-apigateway";
-import * as cf from "aws-cdk-lib/aws-cloudfront";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as s3 from "aws-cdk-lib/aws-s3";
-import * as s3deploy from "aws-cdk-lib/aws-s3-deployment";
 import * as elbv2 from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
-import * as route53 from "aws-cdk-lib/aws-route53";
-import { AwsCustomResource, AwsSdkCall, PhysicalResourceId } from "aws-cdk-lib/custom-resources";
+import { AwsCustomResource, AwsSdkCall } from "aws-cdk-lib/custom-resources";
 import { IpTarget } from "aws-cdk-lib/aws-elasticloadbalancingv2-targets";
 import { Construct } from "constructs";
-import {
-  ExecSyncOptionsWithBufferEncoding,
-  execSync,
-} from "node:child_process";
-import * as path from "node:path";
 import { Shared } from "../shared";
 import { SystemConfig } from "../shared/types";
-import { Utils } from "../shared/utils";
 import { ChatBotApi } from "../chatbot-api";
 import { NagSuppressions } from "cdk-nag";
 
@@ -51,19 +40,30 @@ export class PrivateWebsite extends Construct {
     // 3. In the PHZ, add an "A Record" that points to the Application Load Balancer Alias (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-elb-load-balancer.html)
 
     // Retrieving S3 Endpoint Ips for ALB Target
-    const s3EndpointId = props.shared.s3vpcEndpoint.vpcEndpointId
     const vpc = props.shared.vpc
-    const vpcEndpointNetworkInterfaceIds = props.shared.s3vpcEndpoint.vpcEndpointNetworkInterfaceIds
 
     // First, retrieve the VPC Endpoint
     const vpcEndpointsCall: AwsSdkCall = {
         service: 'EC2',
         action: 'describeVpcEndpoints',
         parameters: {
-            VpcEndpointIds: [s3EndpointId]
+            Filters: [
+              {
+                Name: "vpc-id",
+                Values: [vpc.vpcId]
+              },
+              {
+                Name: "vpc-endpoint-type",
+                Values: ["Interface"]
+              },
+              {
+                Name: "service-name",
+                Values: [ec2.InterfaceVpcEndpointAwsService.S3.name]
+              }
+            ]
         },
         physicalResourceId: cdk.custom_resources.PhysicalResourceId.of('describeNetworkInterfaces'), //PhysicalResourceId.of('describeVpcEndpoints'), 
-        outputPaths: ['VpcEndpoints.0.NetworkInterfaceIds']
+        outputPaths: ['VpcEndpoints.0']
     }
 
     const vpcEndpoints = new AwsCustomResource(
@@ -79,12 +79,14 @@ export class PrivateWebsite extends Construct {
         }
     })
 
+    if (props.config.vpc?.createVpcEndpoints) {
+        vpcEndpoints.node.addDependency(props.shared.s3vpcEndpoint)
+    }
+
     // Then, retrieve the Private IP Addresses for each ENI of the VPC Endpoint
     let s3IPs: IpTarget[] = [];
     for (let index = 0; index < vpc.availabilityZones.length; index++) {
-        
-        const eniId = cdk.Fn.select(index, vpcEndpointNetworkInterfaceIds)
-        
+
         const sdkCall: AwsSdkCall = {
             service: 'EC2',
             action: 'describeNetworkInterfaces',
@@ -205,7 +207,7 @@ export class PrivateWebsite extends Construct {
             principals: [new iam.AnyPrincipal()],
             resources: [props.websiteBucket.bucketArn, `${props.websiteBucket.bucketArn}/*`],
             conditions: {
-                "StringEquals": { "aws:SourceVpce": s3EndpointId }
+                "StringEquals": { "aws:SourceVpce": vpcEndpoints.getResponseField(`VpcEndpoints.0.VpcEndpointId`) }
             }
         })
     );


### PR DESCRIPTION
*Issue #, if available:* #351

*Description of changes:*
- S3 VPC Endpoint ENIs are looked-up based on VPC ID and S3 service name instead of endpoint ID (which might be undefined if `props.config.vpc.createVpcEndpoints = false`)
- Respect `props.config.vpc.createVpcEndpoints` setting for the endpoints required by private website
- Add a dependency on `props.shared.s3vpcEndpoint` IF `props.config.vpc.createVpcEndpoints === true` (since we're not looking up the ENIs based on endpoint ID anymore, the lookup may start before the endpoint has been created)
- Throw an exception if stack region != bedrock region when private website is enabled. We can't do cross-region VPC endpoints (without peering)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
