### PR TITLE
feat(embeddings): adding Cohere and Titan Multimodal

### DIFF
--- a/cli/magic-create.ts
+++ b/cli/magic-create.ts
@@ -34,6 +34,16 @@ const embeddingModels = [
     dimensions: 1536,
   },
   {
+    provider: "bedrock",
+    name: "amazon.titan-embed-image-v1",
+    dimensions: 1024,
+  },
+  {
+    provider: "bedrock",
+    name: "cohere.embed-english-v3",
+    dimensions: 1024,
+  },
+  {
     provider: "openai",
     name: "text-embedding-ada-002",
     dimensions: 1536,

--- a/cli/magic-create.ts
+++ b/cli/magic-create.ts
@@ -44,6 +44,11 @@ const embeddingModels = [
     dimensions: 1024,
   },
   {
+    provider: "bedrock",
+    name: "cohere.embed-multilingual-v3",
+    dimensions: 1024,
+  },
+  {
     provider: "openai",
     name: "text-embedding-ada-002",
     dimensions: 1536,


### PR DESCRIPTION
*Issue #, if available:*
Resolves #218 

*Description of changes:*
Added support for Cohere Embeddings and Titan Multimodal.

- Titan multimodal can only be used for text embeddings
- Cohere Embeddings are created using `search_document` setting as suggested by Cohere documentation for multi-purpose embedding generation (document embeddings and query embeddings)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
