### PR TITLE
feat: adding schedule option for sagemaker models

### DIFF
--- a/cli/aws-cron-expressions.ts
+++ b/cli/aws-cron-expressions.ts
@@ -1,0 +1,60 @@
+export const minuteExp = `(0?[0-9]|[1-5][0-9])`; // [0]0-59
+export const hourExp = `(0?[0-9]|1[0-9]|2[0-3])`; // [0]0-23
+export const dayOfMonthExp = `(0?[1-9]|[1-2][0-9]|3[0-1])`; // [0]1-31
+export const monthExp = `(0?[1-9]|1[0-2]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)`; // [0]1-12 or JAN-DEC
+export const dayOfWeekExp = `([1-7]|SUN|MON|TUE|WED|THU|FRI|SAT)`; // 1-7 or SAT-SUN
+export const yearExp = `((19[8-9][0-9])|(2[0-1][0-9][0-9]))`; // 1980-2199
+export const numbers = `([0-9]*[1-9][0-9]*)`; // whole numbers greater than 0
+
+export function dayOfWeekHash(): string {
+    return `(${dayOfWeekExp}#[1-5])`; // add hash expression to enable supported use case
+}
+
+function rangeRegex(values: string): string {
+    return `(${values}|(\\*\\-${values})|(${values}\\-${values})|(${values}\\-\\*))`;
+}
+
+function listRangeRegex(values: string): string {
+    const range = rangeRegex(values);
+    return `(${range}(\\,${range})*)`;
+}
+
+function slashRegex(values: string): string {
+    const range = rangeRegex(values);
+    return `((\\*|${range}|${values})\\/${numbers})`;
+}
+
+function listSlashRegex(values: string): string {
+    const slash = slashRegex(values);
+    const slashOrRange = `(${slash}|${rangeRegex(values)})`;
+    return `(${slashOrRange}(\\,${slashOrRange})*)`;
+}
+
+function commonRegex(values: string): string {
+    return `(${listRangeRegex(values)}|\\*|${listSlashRegex(values)})`;
+}
+
+export function minuteRegex(): string {
+    return `^(${commonRegex(minuteExp)})$`;
+}
+
+export function hourRegex(): string {
+    return `^(${commonRegex(hourExp)})$`;
+}
+
+export function dayOfMonthRegex(): string {
+    return `^(${commonRegex(dayOfMonthExp)}|\\?|L|LW|${dayOfMonthExp}W)$`;
+}
+
+export function monthRegex(): string {
+    return `^(${commonRegex(monthExp)})$`;
+}
+
+export function dayOfWeekRegex(): string {
+    const rangeList = listRangeRegex(dayOfWeekExp);
+    return `^(${rangeList}|\\*|\\?|${dayOfWeekExp}L|L|L-[1-7]|${dayOfWeekHash()})$`;
+}
+
+export function yearRegex(): string {
+    return `^(${commonRegex(yearExp)})$`;
+}

--- a/cli/aws-cron-validator.ts
+++ b/cli/aws-cron-validator.ts
@@ -1,0 +1,57 @@
+class AWSCronError extends Error {}
+
+import {
+  minuteRegex,
+  hourRegex,
+  dayOfMonthRegex,
+  monthRegex,
+  dayOfWeekRegex,
+  yearRegex,
+} from './aws-cron-expressions';
+
+export class AWSCronValidator {
+
+    public static validate(expression: string): string {
+        if (!expression.trim()) {
+            throw new AWSCronError(
+                `No parameters entered, this format is required in UTC: 0 20 ? * SUN-FRI *`
+            );
+        }
+        const valueCount = expression.split(" ").length;
+        if (valueCount !== 6) {
+          throw new AWSCronError(
+              `Incorrect amount of parameters in '${expression}'. 6 required, ${valueCount} provided.`
+          );
+        }
+
+        const [minute, hour, dayOfMonth, month, dayOfWeek, year] = expression.split(" ");
+
+        // special handling for Day of Month and Day of Week
+        if (!((dayOfMonth === "?" && dayOfWeek !== "?") || (dayOfMonth !== "?" && dayOfWeek === "?"))) {
+            throw new AWSCronError(
+                `Invalid combination of day-of-month '${dayOfMonth}' and day-of-week '${dayOfWeek}'. One must be a question mark (?)`
+            );
+        }
+
+        if (!new RegExp(minuteRegex()).test(minute)) {
+            throw new AWSCronError(`Invalid minute value '${minute}'.`);
+        }
+        if (!new RegExp(hourRegex()).test(hour)) {
+            throw new AWSCronError(`Invalid hour value '${hour}'.`);
+        }
+        if (!new RegExp(dayOfMonthRegex()).test(dayOfMonth)) {
+            throw new AWSCronError(`Invalid day-of-month value '${dayOfMonth}'.`);
+        }
+        if (!new RegExp(monthRegex(), 'i').test(month)) {
+            throw new AWSCronError(`Invalid month value '${month}'.`);
+        }
+        if (!new RegExp(dayOfWeekRegex(), 'i').test(dayOfWeek)) {
+            throw new AWSCronError(`Invalid day-of-week value '${dayOfWeek}'.`);
+        }
+        if (!new RegExp(yearRegex()).test(year)) {
+            throw new AWSCronError(`Invalid year value '${year}'.`);
+        }
+
+        return expression;
+    }
+}

--- a/cli/magic-config.ts
+++ b/cli/magic-config.ts
@@ -13,6 +13,49 @@ import {
 } from "../lib/shared/types";
 import { LIB_VERSION } from "./version.js";
 import * as fs from "fs";
+import { AWSCronValidator } from "./aws-cron-validator"
+import { tz } from 'moment-timezone';
+
+function getTimeZonesWithCurrentTime(): { message: string; name: string }[] {
+    const timeZones = tz.names(); // Get a list of all timezones
+    const timeZoneData = timeZones.map(zone => {
+        // Get current time in each timezone
+        const currentTime = tz(zone).format('YYYY-MM-DD HH:mm');
+        return { message: `${zone}: ${currentTime}`, name: zone };
+    });
+    return timeZoneData;
+}
+
+function isValidDate(dateString: string): boolean {
+  // Check the pattern YYYY/MM/DD
+  const regex = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$/;
+  if (!regex.test(dateString)) {
+    return false;
+  }
+
+  // Parse the date parts to integers
+  const parts = dateString.split("-");
+  const year = parseInt(parts[0], 10);
+  const month = parseInt(parts[1], 10) - 1; // Month is 0-indexed
+  const day = parseInt(parts[2], 10);
+
+  // Check the date validity
+  const date = new Date(year, month, day);
+  if (date.getFullYear() !== year || date.getMonth() !== month || date.getDate() !== day) {
+    return false;
+  }
+  
+  // Check if the date is in the future compared to the current date at 00:00:00
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  if (date <= today) {
+    return false;
+  }
+
+  return true;
+}
+
+const timeZoneData = getTimeZonesWithCurrentTime();
 
 const iamRoleRegExp = RegExp(/arn:aws:iam::\d+:role\/[\w-_]+/);
 const kendraIdRegExp = RegExp(/^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/);
@@ -86,6 +129,16 @@ const embeddingModels = [
       options.enableSagemakerModels = config.llms?.sagemaker
         ? config.llms?.sagemaker.length > 0
         : false;
+      options.enableSagemakerModelsSchedule = config.llms?.sagemakerSchedule?.enabled;
+      options.timezonePicker = config.llms?.sagemakerSchedule?.timezonePicker;
+      options.enableCronFormat = config.llms?.sagemakerSchedule?.enableCronFormat;
+      options.cronSagemakerModelsScheduleStart = config.llms?.sagemakerSchedule?.sagemakerCronStartSchedule;
+      options.cronSagemakerModelsScheduleStop = config.llms?.sagemakerSchedule?.sagemakerCronStopSchedule;
+      options.daysForSchedule = config.llms?.sagemakerSchedule?.daysForSchedule;
+      options.scheduleStartTime = config.llms?.sagemakerSchedule?.scheduleStartTime;
+      options.scheduleStopTime = config.llms?.sagemakerSchedule?.scheduleStopTime;
+      options.enableScheduleEndDate = config.llms?.sagemakerSchedule?.enableScheduleEndDate;
+      options.startScheduleEndDate = config.llms?.sagemakerSchedule?.startScheduleEndDate;
       options.enableRag = config.rag.enabled;
       options.ragsToEnable = Object.keys(config.rag.engines ?? {}).filter(
         (v: string) => (config.rag.engines as any)[v].enabled
@@ -234,6 +287,8 @@ async function processCreateOptions(options: any): Promise<void> {
             .includes(m)
         ) || [],
       validate(choices: any) {
+        //Trap for new players, validate always runs even if skipped is true
+        // So need to handle validate bail out if skipped is true
         return (this as any).skipped || choices.length > 0
           ? true
           : "You need to select at least one model";
@@ -242,6 +297,181 @@ async function processCreateOptions(options: any): Promise<void> {
         (this as any).state._choices = (this as any).state.choices;
         return !(this as any).state.answers.enableSagemakerModels;
       },
+    },
+    {
+      type: "confirm",
+      name: "enableSagemakerModelsSchedule",
+      message: "Do you want to enable a start/stop schedule for sagemaker models?",
+      initial(): boolean {
+        return (options.enableSagemakerModelsSchedule && (this as any).state.answers.enableSagemakerModels) || false;
+      },
+      skip(): boolean {
+        return !(this as any).state.answers.enableSagemakerModels;
+      },
+    },
+    {
+      type: "AutoComplete",
+      name: "timezonePicker",
+      hint: "start typing to auto complete, ENTER to confirm selection",
+      message: "Which TimeZone do you want to run the schedule in?",
+      choices: timeZoneData,
+      validate(choices: any) {
+        return (this as any).skipped || choices.length > 0
+          ? true
+          : "You need to select at least one time zone";
+      },
+      skip(): boolean {
+        return !(this as any).state.answers.enableSagemakerModelsSchedule;
+      },
+      initial: options.timezonePicker || [],
+    },
+    {
+      type: "select",
+      name: "enableCronFormat",
+      choices: [
+        { message: "Simple - Wizard lead", name: "simple" },
+        { message: "Advanced - Provide cron expression", name: "cron" },
+      ],
+      message: "How do you want to set the schedule?",
+      initial: options.enableCronFormat || "simple",
+      skip(): boolean {
+        (this as any).state._choices = (this as any).state.choices;
+        return !(this as any).state.answers.enableSagemakerModelsSchedule;
+      },
+    },
+    {
+      type: "input",
+      name: "sagemakerCronStartSchedule",
+      hint: "This cron format is using AWS eventbridge cron syntax see docs for more information",
+      message: "Start schedule for Sagmaker models expressed in UTC AWS cron format",
+      skip(): boolean {
+        return !(this as any).state.answers.enableCronFormat.includes("cron");
+      },
+      validate(v: string) {
+        if ((this as any).skipped) {
+          return true
+        }
+        try {
+          AWSCronValidator.validate(v)
+          return true
+        }
+        catch (error) {
+          if (error instanceof Error){
+            return error.message
+          }
+          return false
+        }
+      },
+      initial: options.cronSagemakerModelsScheduleStart,
+    },
+    {
+      type: "input",
+      name: "sagemakerCronStopSchedule",
+      hint: "This cron format is using AWS eventbridge cron syntax see docs for more information",
+      message: "Stop schedule for Sagmaker models expressed in AWS cron format",
+      skip(): boolean {
+        return !(this as any).state.answers.enableCronFormat.includes("cron");
+      },
+      validate(v: string) {
+        if ((this as any).skipped) {
+          return true
+        }
+        try {
+          AWSCronValidator.validate(v)
+          return true
+        }
+        catch (error) {
+          if (error instanceof Error){
+            return error.message
+          }
+          return false
+        }
+      },
+      initial: options.cronSagemakerModelsScheduleStop,
+    },
+    {
+      type: "multiselect",
+      name: "daysForSchedule",
+      hint: "SPACE to select, ENTER to confirm selection",
+      message: "Which days of the week would you like to run the schedule on?",
+      choices: [
+        { message: "Sunday", name: "SUN" },
+        { message: "Monday", name: "MON" },
+        { message: "Tuesday", name: "TUE" },
+        { message: "Wednesday", name: "WED" },
+        { message: "Thursday", name: "THU" },
+        { message: "Friday", name: "FRI" },
+        { message: "Saturday", name: "SAT" },
+      ],
+      validate(choices: any) {
+        return (this as any).skipped || choices.length > 0
+          ? true
+          : "You need to select at least one day";
+      },
+      skip(): boolean {
+        (this as any).state._choices = (this as any).state.choices;
+        return !(this as any).state.answers.enableCronFormat.includes("simple");
+      },
+      initial: options.daysForSchedule || [],
+    },
+    {
+      type: "input",
+      name: "scheduleStartTime",
+      message: "What time of day do you wish to run the start schedule? enter in HH:MM format",
+      validate(v: string) {
+        if ((this as any).skipped) {
+          return true
+        }
+        // Regular expression to match HH:MM format
+        const regex = /^([0-1]?[0-9]|2[0-3]):([0-5]?[0-9])$/;
+        return regex.test(v) || 'Time must be in HH:MM format!';
+      },
+      skip(): boolean {
+        return !(this as any).state.answers.enableCronFormat.includes("simple");
+      },
+      initial: options.scheduleStartTime,
+    },
+    {
+      type: "input",
+      name: "scheduleStopTime",
+      message: "What time of day do you wish to run the stop schedule? enter in HH:MM format",
+      validate(v: string) {
+        if ((this as any).skipped) {
+          return true
+        }
+        // Regular expression to match HH:MM format
+        const regex = /^([0-1]?[0-9]|2[0-3]):([0-5]?[0-9])$/;
+        return regex.test(v) || 'Time must be in HH:MM format!';
+      },
+      skip(): boolean {
+        return !(this as any).state.answers.enableCronFormat.includes("simple");
+      },
+      initial: options.scheduleStopTime,
+    },
+    {
+      type: "confirm",
+      name: "enableScheduleEndDate",
+      message: "Would you like to set an end data for the start schedule? (after this date the models would no longer start)",
+      initial: options.enableScheduleEndDate || false,
+      skip(): boolean {
+        return !(this as any).state.answers.enableSagemakerModelsSchedule;
+      },
+    },
+    {
+      type: "input",
+      name: "startScheduleEndDate",
+      message: "After this date the models will no longer start",
+      hint: "YYYY-MM-DD",
+      validate(v: string) {
+        if ((this as any).skipped) {
+          return true
+        }
+        return isValidDate(v) || 'The date must be in format YYYY/MM/DD and be in the future';
+      },
+      skip(): boolean {
+        return !(this as any).state.answers.enableScheduleEndDate;
+      },
+      initial: options.startScheduleEndDate || false,
     },
     {
       type: "confirm",
@@ -387,6 +617,22 @@ async function processCreateOptions(options: any): Promise<void> {
   ];
   const models: any = await enquirer.prompt(modelsPrompts);
 
+  // Convert simple time into cron format for schedule
+  if (answers.enableSagemakerModelsSchedule && answers.enableCronFormat == "simple")
+  {
+    const daysToRunSchedule = answers.daysForSchedule.join(",");
+    const startMinutes = answers.scheduleStartTime.split(":")[1];
+    const startHour = answers.scheduleStartTime.split(":")[0];
+    answers.sagemakerCronStartSchedule = `${startMinutes} ${startHour} ? * ${daysToRunSchedule} *`;
+    AWSCronValidator.validate(answers.sagemakerCronStartSchedule)
+
+    
+    const stopMinutes = answers.scheduleStopTime.split(":")[1];
+    const stopHour = answers.scheduleStopTime.split(":")[0];
+    answers.sagemakerCronStopSchedule = `${stopMinutes} ${stopHour} ? * ${daysToRunSchedule} *`;
+    AWSCronValidator.validate(answers.sagemakerCronStopSchedule)
+  }
+  
   // Create the config object
   const config = {
     prefix: answers.prefix,
@@ -409,6 +655,20 @@ async function processCreateOptions(options: any): Promise<void> {
       : undefined,
     llms: {
       sagemaker: answers.sagemakerModels,
+      sagemakerSchedule: answers.enableSagemakerModelsSchedule
+        ? {
+            enabled: answers.enableSagemakerModelsSchedule,
+            timezonePicker: answers.timezonePicker,
+            enableCronFormat: answers.enableCronFormat,
+            sagemakerCronStartSchedule: answers.sagemakerCronStartSchedule,
+            sagemakerCronStopSchedule: answers.sagemakerCronStopSchedule,
+            daysForSchedule: answers.daysForSchedule,
+            scheduleStartTime: answers.scheduleStartTime,
+            scheduleStopTime: answers.scheduleStopTime,
+            enableScheduleEndDate: answers.enableScheduleEndDate,
+            startScheduleEndDate: answers.startScheduleEndDate,
+          }
+        : undefined,
     },
     rag: {
       enabled: answers.enableRag,

--- a/docs/documentation/sagemaker-schedule.md
+++ b/docs/documentation/sagemaker-schedule.md
@@ -1,0 +1,17 @@
+# Sagemaker Schedule
+
+This feature set during the installation setup allows the user to set a cron schedule to start and stop their sagemaker hosted models if they enabled any.
+
+As specificed during setup the user has a choice between Simple and CRON Format.
+
+Cron is more powerful in terms of its scheduling capability but Simple should suffice for most users.
+
+The schedule if enabled and set during the setup utilises the Amazone EventBridge Scheduler to coordinate the starting and stopping of the models for the given schedule.
+
+Amazon EventBridge Scheduler utilises a specific cron format and you can read about that in the [EventBridge docs](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html)
+
+### Limitations
+
+The sagemaker endpoint must be active when running further CDK deployments otherwise some dependencies will fail attempting to enumerate the sagemaker endpoint.
+
+If this happens and you need to run a deployment simply use the AWS Console to re-create the sagemaker endpoint and then continue the CDK deployment.

--- a/lib/models/sagemaker-schedule.ts
+++ b/lib/models/sagemaker-schedule.ts
@@ -1,0 +1,63 @@
+import * as cdk from 'aws-cdk-lib';
+import * as scheduler from 'aws-cdk-lib/aws-scheduler';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as sagemaker from "aws-cdk-lib/aws-sagemaker";
+import { Construct } from 'constructs';
+import { Utils } from "../shared/utils";
+import {
+  SystemConfig,
+} from "../shared/types";
+
+export function createStartSchedule(scope: Construct, id: string, sagemakerEndpoint: sagemaker.CfnEndpoint, role: iam.Role, config: SystemConfig) {
+  const scheduleName = Utils.getName(config, `startSchedule-${sagemakerEndpoint.endpointName}`, 64);
+  const scheduleExpression = config.llms?.sagemakerSchedule?.sagemakerCronStartSchedule;
+  const timeZone = config.llms?.sagemakerSchedule?.timezonePicker;
+  const enableScheduleEndDate = config.llms?.sagemakerSchedule?.enableScheduleEndDate;
+  const scheduleEndDate = config.llms?.sagemakerSchedule?.startScheduleEndDate;
+  const startSchedule = new scheduler.CfnSchedule(scope, scheduleName, {
+    name: scheduleName,
+    description: `created to start model endpoint ${sagemakerEndpoint.endpointName} for ${scheduleName}`,
+    flexibleTimeWindow: {
+      maximumWindowInMinutes: 5,
+      mode: 'FLEXIBLE',
+    },
+    scheduleExpression: `cron(${scheduleExpression})`,
+    scheduleExpressionTimezone: timeZone,
+    state: 'ENABLED',
+    endDate: enableScheduleEndDate ? `${scheduleEndDate}T00:00:59.000Z` : undefined,
+    target: {
+      arn: 'arn:aws:scheduler:::aws-sdk:sagemaker:createEndpoint',
+      input: JSON.stringify({
+        EndpointName: sagemakerEndpoint.endpointName,
+        EndpointConfigName: sagemakerEndpoint.endpointConfigName,
+      }),
+      roleArn: role.roleArn,
+    },
+  });
+  return startSchedule;
+}
+
+export function createStopSchedule(scope: Construct, id: string, sagemakerEndpoint: sagemaker.CfnEndpoint, role: iam.Role, config: SystemConfig) {
+  const scheduleName = Utils.getName(config, `stopSchedule-${sagemakerEndpoint.endpointName}`, 64);
+  const scheduleExpression = config.llms?.sagemakerSchedule?.sagemakerCronStopSchedule;
+  const timeZone = config.llms?.sagemakerSchedule?.timezonePicker;
+  const stopSchedule = new scheduler.CfnSchedule(scope, scheduleName, {
+    name: scheduleName,
+    description: `created to stop model endpoint ${sagemakerEndpoint.endpointName} for ${scheduleName}`,
+    flexibleTimeWindow: {
+      maximumWindowInMinutes: 5,
+      mode: 'FLEXIBLE',
+    },
+    scheduleExpression: `cron(${scheduleExpression})`,
+    scheduleExpressionTimezone: timeZone,
+    state: 'ENABLED',
+    target: {
+      arn: 'arn:aws:scheduler:::aws-sdk:sagemaker:deleteEndpoint',
+      input: JSON.stringify({
+        EndpointName: sagemakerEndpoint.endpointName,
+      }),
+      roleArn: role.roleArn,
+    },
+  });
+  return stopSchedule;
+}

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -84,6 +84,18 @@ export interface SystemConfig {
   };
   llms: {
     sagemaker: SupportedSageMakerModels[];
+    sagemakerSchedule?: {
+      enabled?: boolean;
+      timezonePicker?: string;
+      enableCronFormat?: boolean;
+      sagemakerCronStartSchedule?: string;
+      sagemakerCronStopSchedule?: string;
+      daysForSchedule?: string;
+      scheduleStartTime?: string;
+      scheduleStopTime?: string;
+      enableScheduleEndDate?: boolean;
+      startScheduleEndDate?: string;
+    };
   };
   rag: {
     enabled: boolean;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "commander": "^11.0.0",
         "constructs": "^10.0.0",
         "enquirer": "^2.4.1",
+        "moment-timezone": "^0.5.45",
         "source-map-support": "^0.5.21"
       },
       "bin": {
@@ -4060,6 +4061,25 @@
       "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.2.0.tgz",
       "integrity": "sha512-BECkorDF1TY2rGKt9XHdSeP9TP29yUbrAaCh/C03wpyf1vx3uYcP/+8XlMcpTkgoU0rBVnHMAOaP83Rc9Tm+TQ==",
       "dev": true
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.45",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
+      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "commander": "^11.0.0",
     "constructs": "^10.0.0",
     "enquirer": "^2.4.1",
+    "moment-timezone": "^0.5.45",
     "source-map-support": "^0.5.21"
   },
   "optionalDependencies": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change implements the ability to set a schedule via event bridge to toggle on and off the sagemaker hosted models. Typically the solution is consumed during business hours so enabling a schedule to suit those hours makes sense. See updated docs for more information.

I had to build a class to validate the peculiar cron expression format that Event Bridge supports to help give feedback to users inputting a cron expression early, rather than waiting for a deployment to fail later.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
