### PR TITLE
Add support for Mistral models via Bedrock

### DIFF
--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/__init__.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/__init__.py
@@ -3,3 +3,4 @@ from .titan import *
 from .ai21_j2 import *
 from .cohere import *
 from .llama2_chat import *
+from .mistral import *

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/llama2_chat.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/llama2_chat.py
@@ -62,6 +62,6 @@ class BedrockMetaLLama2ChatAdapter(ModelAdapter):
 
 # Register the adapter
 registry.register(
-    r"(^bedrock.meta.llama2-.*-chat.*|^bedrock.mistral.mi.*)",
+    r"^bedrock.meta.llama2-.*-chat.*",
     BedrockMetaLLama2ChatAdapter,
 )

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/llama2_chat.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/llama2_chat.py
@@ -61,4 +61,7 @@ class BedrockMetaLLama2ChatAdapter(ModelAdapter):
 
 
 # Register the adapter
-registry.register(r"(?i)^bedrock.meta.llama2-.*-chat.*", BedrockMetaLLama2ChatAdapter)
+registry.register(
+    r"(^bedrock.meta.llama2-.*-chat.*|^bedrock.mistral.mi.*)",
+    BedrockMetaLLama2ChatAdapter,
+)

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/mistral.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/mistral.py
@@ -1,0 +1,12 @@
+from .llama2_chat import BedrockMetaLLama2ChatAdapter
+from ..registry import registry
+
+
+class BedrockMistralAdapter(BedrockMetaLLama2ChatAdapter): ...
+
+
+# Register the adapter
+registry.register(
+    r"^bedrock.mistral.mi.*",
+    BedrockMistralAdapter,
+)

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/shared/meta/llama2_chat.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/shared/meta/llama2_chat.py
@@ -5,31 +5,25 @@ from langchain.memory import ConversationBufferMemory
 from langchain.prompts import PromptTemplate
 
 
-Llama2ChatPrompt = """<<SYS>>
+Llama2ChatPrompt = """<s>[INST] <<SYS>>
 You are an helpful assistant that provides concise answers to user questions with as little sentences as possible and at maximum 3 sentences. You do not repeat yourself. You avoid bulleted list or emojis.
 <</SYS>>
 
-{chat_history}
+{chat_history}<s>[INST] Context: {input} [/INST]"""
 
-{input} [/INST]"""
-
-Llama2ChatQAPrompt = """<<SYS>>
+Llama2ChatQAPrompt = """<s>[INST] <<SYS>>
 Use the following conversation history and pieces of context to answer the question at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer. You do not repeat yourself. You avoid bulleted list or emojis.
 <</SYS>>
 
-{chat_history}
-
-[INST] Context: {context} [/INST]
+{chat_history}<s>[INST] Context: {context}
 
 {question} [/INST]"""
 
-Llama2ChatCondensedQAPrompt = """<<SYS>>
+Llama2ChatCondensedQAPrompt = """<s>[INST] <<SYS>>
 Given the following conversation and the question at the end, rephrase the follow up input to be a standalone question, in the same language as the follow up input. You do not repeat yourself. You avoid bulleted list or emojis.
 <</SYS>>
 
-{chat_history}
-
-{question} [/INST]"""
+{chat_history}<s>[INST] {question} [/INST]"""
 
 
 Llama2ChatPromptTemplate = PromptTemplate.from_template(Llama2ChatPrompt)
@@ -53,7 +47,7 @@ class Llama2ConversationBufferMemory(ConversationBufferMemory):
                 if human_message_cnt == 0:
                     message = f"{m.content} [/INST]"
                 else:
-                    message = f"<s> [INST] {m.content} [/INST]"
+                    message = f"<s>[INST] {m.content} [/INST]"
                 human_message_cnt += 1
             elif isinstance(m, AIMessage):
                 message = f"{m.content} </s>"


### PR DESCRIPTION
*Issue #, if available:*

Resolves: #390 

*Description of changes:*
Given that the prompt format of Mistral and Mixtral are identical to Llama2, we reused the Llama2 adapter registering it also for Mistral models

The input and output adaptations are different and taken care by the base Bedrock LLM class

Finally, we revised the LLama2 prompts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
