### PR TITLE
Ability to specify Aurora DB Name for storing embeddings

### DIFF
--- a/cli/magic-config.ts
+++ b/cli/magic-config.ts
@@ -80,6 +80,7 @@ const embeddingModels = [
       ) {
         options.ragsToEnable.pop("kendra");
       }
+      options.auroraDefaultDBName = config.rag.engines?.aurora?.defaultDatabaseName
       options.embeddings = config.rag.embeddingsModels.map((m: any) => m.name);
       options.defaultEmbedding = (config.rag.embeddingsModels ?? []).filter(
         (m: any) => m.default
@@ -256,6 +257,20 @@ async function processCreateOptions(options: any): Promise<void> {
       initial: options.ragsToEnable || [],
     },
     {
+      type:"input",
+      name:"auroraDefaultDBName",
+      message: "Enter a default database name for Aurora",
+      initial: options.auroraDefaultDBName,
+      validate(v: string) {
+        return (v.length === 0 || (this as any).skipped || 
+          RegExp(/^[a-zA-Z][a-zA-Z0-9_]{0,62}$/).test(v)) ? 
+            true : "You need to enter a valid database name";
+      },
+      skip(): boolean {
+        return !(this as any).state.answers.ragsToEnable.includes("aurora");
+      },
+    },
+    {
       type: "confirm",
       name: "kendraEnterprise",
       message: "Do you want to enable Kendra Enterprise Edition?",
@@ -392,6 +407,8 @@ async function processCreateOptions(options: any): Promise<void> {
       engines: {
         aurora: {
           enabled: answers.ragsToEnable.includes("aurora"),
+          defaultDatabaseName: answers.ragsToEnable.includes("aurora") && answers.auroraDefaultDBName.length > 0 ? 
+            answers.auroraDefaultDBName : undefined
         },
         opensearch: {
           enabled: answers.ragsToEnable.includes("opensearch"),

--- a/cli/magic-config.ts
+++ b/cli/magic-config.ts
@@ -58,6 +58,9 @@ const embeddingModels = [
         fs.readFileSync("./bin/config.json").toString("utf8")
       );
       options.prefix = config.prefix;
+      options.vpc = config.vpc ? true : false;
+      options.vpcId = config.vpc?.vpcId;
+      options.createVpcEndpoints = config.vpc?.createVpcEndpoints;
       options.privateWebsite = config.privateWebsite;
       options.certificate = config.certificate;
       options.domain = config.domain;
@@ -116,6 +119,34 @@ async function processCreateOptions(options: any): Promise<void> {
       message: "Prefix to differentiate this deployment",
       initial: options.prefix,
       askAnswered: false,
+    },
+    {
+      type: "confirm",
+      name: "existingVpc",
+      message: "Do you want to use existing vpc? (selecting false will create a new vpc)",
+      initial: options.vpc || false,
+    },
+    {
+      type: "input",
+      name: "vpcId",
+      message: "Specify existing VpcId (vpc-xxxxxxxxxxxxxxxxx)",
+      initial: options.vpcId,
+      validate: (vpcId: string) =>{
+        return RegExp(/^vpc-[0-9a-f]{8,17}$/i).test(vpcId) ? true
+         : "Enter a valid VpcId in vpc-0123456abdef format"
+      },
+      skip(): boolean {
+        return !(this as any).state.answers.existingVpc;
+      },
+    },
+    {
+      type: "confirm",
+      name: "createVpcEndpoints",
+      message: "Do you want create VPC Endpoints?",
+      initial: options.createVpcEndpoints || false,
+      skip(): boolean {
+        return !(this as any).state.answers.existingVpc;
+      },
     },
     {
       type: "confirm",
@@ -337,6 +368,12 @@ async function processCreateOptions(options: any): Promise<void> {
   // Create the config object
   const config = {
     prefix: answers.prefix,
+    vpc: answers.existingVpc
+      ? {
+          vpcId: answers.vpcId.toLowerCase(),
+          createVpcEndpoints: answers.createVpcEndpoints,
+      }
+      : undefined,
     privateWebsite: answers.privateWebsite,
     certificate: answers.certificate,
     domain: answers.domain,

--- a/cli/magic-config.ts
+++ b/cli/magic-config.ts
@@ -58,7 +58,6 @@ const embeddingModels = [
         fs.readFileSync("./bin/config.json").toString("utf8")
       );
       options.prefix = config.prefix;
-      options.vpc = config.vpc ? true : false;
       options.vpcId = config.vpc?.vpcId;
       options.createVpcEndpoints = config.vpc?.createVpcEndpoints;
       options.privateWebsite = config.privateWebsite;
@@ -124,16 +123,16 @@ async function processCreateOptions(options: any): Promise<void> {
       type: "confirm",
       name: "existingVpc",
       message: "Do you want to use existing vpc? (selecting false will create a new vpc)",
-      initial: options.vpc || false,
+      initial: options.vpcId ? true : false,
     },
     {
       type: "input",
       name: "vpcId",
       message: "Specify existing VpcId (vpc-xxxxxxxxxxxxxxxxx)",
       initial: options.vpcId,
-      validate: (vpcId: string) =>{
-        return RegExp(/^vpc-[0-9a-f]{8,17}$/i).test(vpcId) ? true
-         : "Enter a valid VpcId in vpc-0123456abdef format"
+      validate(vpcId: string) {
+        return ((this as any).skipped || RegExp(/^vpc-[0-9a-f]{8,17}$/i).test(vpcId)) ?
+          true : 'Enter a valid VpcId in vpc-xxxxxxxxxxx format'
       },
       skip(): boolean {
         return !(this as any).state.answers.existingVpc;

--- a/cli/magic-config.ts
+++ b/cli/magic-config.ts
@@ -80,7 +80,7 @@ const embeddingModels = [
       ) {
         options.ragsToEnable.pop("kendra");
       }
-      options.auroraDefaultDBName = config.rag.engines?.aurora?.defaultDatabaseName
+      options.auroraDefaultDBName = config.rag.engines.aurora.defaultDatabaseName
       options.embeddings = config.rag.embeddingsModels.map((m: any) => m.name);
       options.defaultEmbedding = (config.rag.embeddingsModels ?? []).filter(
         (m: any) => m.default

--- a/lib/rag-engines/aurora-pgvector/functions/pgvector-setup/index.py
+++ b/lib/rag-engines/aurora-pgvector/functions/pgvector-setup/index.py
@@ -20,15 +20,18 @@ def lambda_handler(event, context: LambdaContext):
         SecretId=AURORA_DB_SECRET_ID
     )
     database_secrets = json.loads(secret_response["SecretString"])
-    dbhost = database_secrets["host"]
-    dbport = database_secrets["port"]
-    dbuser = database_secrets["username"]
-    dbpass = database_secrets["password"]
 
     if request_type == "Create" or request_type == "Update":
-        dbconn = psycopg2.connect(
-            host=dbhost, user=dbuser, password=dbpass, port=dbport, connect_timeout=10
-        )
+        db_conn_args = {
+            "host": database_secrets["host"],
+            "user": database_secrets["username"],
+            "password": database_secrets["password"],
+            "port": database_secrets["port"],
+            "connect_timeout":10,
+        }
+        if "dbname" in database_secrets:
+            db_conn_args["dbname"] = database_secrets["dbname"]
+        dbconn = psycopg2.connect(**db_conn_args)
 
         dbconn.set_session(autocommit=True)
 

--- a/lib/rag-engines/aurora-pgvector/index.ts
+++ b/lib/rag-engines/aurora-pgvector/index.ts
@@ -27,11 +27,6 @@ export class AuroraPgVector extends Construct {
   constructor(scope: Construct, id: string, props: AuroraPgVectorProps) {
     super(scope, id);
 
-    const rdsKey = new kms.Key(this, "RDSKey", {
-      enableKeyRotation: true,
-      description: "Key for RDS",
-    });
-
     const dbCluster = new rds.DatabaseCluster(this, "AuroraDatabase", {
       engine: rds.DatabaseClusterEngine.auroraPostgres({
         version: rds.AuroraPostgresEngineVersion.VER_15_3,
@@ -42,7 +37,6 @@ export class AuroraPgVector extends Construct {
       vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_ISOLATED },
       iamAuthentication: true,
       defaultDatabaseName: props.config.rag.engines.aurora.defaultDatabaseName,
-      storageEncryptionKey:  rdsKey,
     });
 
     const databaseSetupFunction = new lambda.Function(

--- a/lib/rag-engines/aurora-pgvector/index.ts
+++ b/lib/rag-engines/aurora-pgvector/index.ts
@@ -9,6 +9,7 @@ import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as logs from "aws-cdk-lib/aws-logs";
 import * as rds from "aws-cdk-lib/aws-rds";
+import * as kms from "aws-cdk-lib/aws-kms";
 import * as cr from "aws-cdk-lib/custom-resources";
 import * as sfn from "aws-cdk-lib/aws-stepfunctions";
 import { NagSuppressions } from "cdk-nag";
@@ -26,6 +27,11 @@ export class AuroraPgVector extends Construct {
   constructor(scope: Construct, id: string, props: AuroraPgVectorProps) {
     super(scope, id);
 
+    const rdsKey = new kms.Key(this, "RDSKey", {
+      enableKeyRotation: true,
+      description: "Key for RDS",
+    });
+
     const dbCluster = new rds.DatabaseCluster(this, "AuroraDatabase", {
       engine: rds.DatabaseClusterEngine.auroraPostgres({
         version: rds.AuroraPostgresEngineVersion.VER_15_3,
@@ -35,6 +41,8 @@ export class AuroraPgVector extends Construct {
       vpc: props.shared.vpc,
       vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_ISOLATED },
       iamAuthentication: true,
+      defaultDatabaseName: props.config.rag.engines.aurora.defaultDatabaseName,
+      storageEncryptionKey:  rdsKey,
     });
 
     const databaseSetupFunction = new lambda.Function(

--- a/lib/rag-engines/aurora-pgvector/index.ts
+++ b/lib/rag-engines/aurora-pgvector/index.ts
@@ -9,7 +9,6 @@ import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as logs from "aws-cdk-lib/aws-logs";
 import * as rds from "aws-cdk-lib/aws-rds";
-import * as kms from "aws-cdk-lib/aws-kms";
 import * as cr from "aws-cdk-lib/custom-resources";
 import * as sfn from "aws-cdk-lib/aws-stepfunctions";
 import { NagSuppressions } from "cdk-nag";

--- a/lib/shared/layers/python-sdk/python/genai_core/aurora/connection.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/aurora/connection.py
@@ -21,15 +21,20 @@ class AuroraConnection(object):
         self.dbport = database_secrets["port"]
         self.dbuser = database_secrets["username"]
         self.dbpass = database_secrets["password"]
+        if "dbname" in database_secrets:
+            self.dbname = database_secrets["dbname"]
 
     def __enter__(self):
-        connection = psycopg2.connect(
-            host=self.dbhost,
-            user=self.dbuser,
-            password=self.dbpass,
-            port=self.dbport,
-            connect_timeout=10,
-        )
+        db_conn_args = {
+             "host":self.dbhost,
+            "user":self.dbuser,
+            "password":self.dbpass,
+            "port":self.dbport,
+            "connect_timeout":10,
+        }
+        if hasattr(self, "dbname"):
+            db_conn_args["dbname"] = self.dbname
+        connection = psycopg2.connect(**db_conn_args)
 
         connection.set_session(autocommit=self.autocommit)
         psycopg2.extras.register_uuid()

--- a/lib/shared/layers/python-sdk/python/genai_core/aurora/connection.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/aurora/connection.py
@@ -26,7 +26,7 @@ class AuroraConnection(object):
 
     def __enter__(self):
         db_conn_args = {
-             "host":self.dbhost,
+            "host":self.dbhost,
             "user":self.dbuser,
             "password":self.dbpass,
             "port":self.dbport,

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -90,6 +90,7 @@ export interface SystemConfig {
     engines: {
       aurora: {
         enabled: boolean;
+        defaultDatabaseName?: string;
       };
       opensearch: {
         enabled: boolean;


### PR DESCRIPTION
*Issue #389 , if available:*

*Description of changes:*
* Added CLI option to capture a default database name from user while selecting Aurora Rag Engine
* Optionally pass the database name (if specified) while establishing connection to Aurora


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
