### PR TITLE
Improved streaming experience

### DIFF
--- a/lib/chatbot-api/functions/outgoing-message-appsync/index.ts
+++ b/lib/chatbot-api/functions/outgoing-message-appsync/index.ts
@@ -58,7 +58,7 @@ export const handler = async (
     try {
       const x: number = JSON.parse(a.body).Message.data?.token?.sequenceNumber;
       const y: number = JSON.parse(b.body).Message.data?.token?.sequenceNumber;
-      return x > y ? 1 : x === y ? 0 : -1;
+      return x - y;
     } catch {
       return 0;
     }

--- a/lib/chatbot-api/functions/outgoing-message-appsync/index.ts
+++ b/lib/chatbot-api/functions/outgoing-message-appsync/index.ts
@@ -19,8 +19,9 @@ const recordHandler = async (record: SQSRecord): Promise<void> => {
   const payload = record.body;
   if (payload) {
     const item = JSON.parse(payload);
-    logger.info("Processed item", { item });
+
     const req = JSON.parse(item.Message);
+    logger.debug("Processed message", req);
     /***
      * Payload format
      * 
@@ -42,9 +43,9 @@ const recordHandler = async (record: SQSRecord): Promise<void> => {
           }
         }
     `;
-    logger.info(query);
+    //logger.info(query);
     const resp = await graphQlQuery(query);
-    logger.info(resp);
+    //logger.info(resp);
   }
 };
 
@@ -52,6 +53,16 @@ export const handler = async (
   event: SQSEvent,
   context: Context
 ): Promise<SQSBatchResponse> => {
+  logger.debug("Event", { event });
+  event.Records = event.Records.sort((a, b) => {
+    try {
+      const x: number = JSON.parse(a.body).Message.data?.token?.sequenceNumber;
+      const y: number = JSON.parse(b.body).Message.data?.token?.sequenceNumber;
+      return x > y ? 1 : x === y ? 0 : -1;
+    } catch {
+      return 0;
+    }
+  });
   return processPartialResponse(event, recordHandler, processor, {
     context,
   });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When using streaming mode, single tokens are published to SQS and then processed by a lambda function in micro-batches of 10 items. 
Each message is then published as a mutation to AppSync and triggers a refresh of the UI. Tokens are reordered client side before the resulting text is displayed.

We have noticed that the text is often scrambled and upon each refresh it gets reordered. Upon investigation this is due to the fact that records in SQS batches are not in order and Lambda Powertools batch processor processes the records in the same order as they are received. This causes a lot of reordering client side since token are received individually.

Eg:

```
Batch: [friend!, Hello, my]

Client:
friend -> "friend!"

Client:
Hello -> "Hello friend!"

Client:
my -> "Hello my friend!"
```

To improve the experience we sort the records in he batch based on their `sequenceNumber` before passing them to the Lambda Powertools batch processor. 
In the same example as above the batch will be reordered as [Hello, my, friend!] and the tokens sent in the correct order.
This is not an absolute ordering but improves the experience significantly already.

With this implementation we observed that client side the maximum number of  token reordering is massively reduced from an average of 6-10 per received token to an average of 0-1.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
