### PR TITLE
Continue to use multimodal mode in a chat using images

### DIFF
--- a/lib/user-interface/react-app/src/components/chatbot/chat-input-panel.tsx
+++ b/lib/user-interface/react-app/src/components/chatbot/chat-input-panel.tsx
@@ -329,7 +329,9 @@ export default function ChatInputPanel(props: ChatInputPanelProps) {
     const request: ChatBotRunRequest = {
       action: ChatBotAction.Run,
       modelInterface:
-        props.configuration.files && props.configuration.files.length > 0
+        (props.configuration.files && props.configuration.files.length > 0) ||
+        messageHistoryRef.current.filter((x) => x.metadata?.files !== undefined)
+          .length > 0
           ? "multimodal"
           : (state.selectedModelMetadata!.interface as ModelInterface),
       data: {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Multimodal chat is trigger by the upload of an image in the input box, but on subsequent chats the normal text chat mode (langchain) would be if no new image is uploaded.

We now check if there are any images in the chat history, and if that is the case, we continue to use the `multimodal` chat mode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
