### PR TITLE
Add setting for automatic creation of cloudwatch role on Api Gateway

### DIFF
--- a/lib/aws-genai-llm-chatbot-stack.ts
+++ b/lib/aws-genai-llm-chatbot-stack.ts
@@ -191,6 +191,7 @@ export class AwsGenAILLMChatbotStack extends cdk.Stack {
         `/${this.stackName}/ChatBotApi/Realtime/Resolvers/outgoing-message-handler/ServiceRole/DefaultPolicy/Resource`,
         `/${this.stackName}/IdeficsInterface/IdeficsInterfaceRequestHandler/ServiceRole/DefaultPolicy/Resource`,
         `/${this.stackName}/IdeficsInterface/IdeficsInterfaceRequestHandler/ServiceRole/Resource`,
+        `/${this.stackName}/IdeficsInterface/ChatbotFilesPrivateApi/CloudWatchRole/Resource`,
         `/${this.stackName}/IdeficsInterface/S3IntegrationRole/DefaultPolicy/Resource`,
       ],
       [

--- a/lib/model-interfaces/idefics/index.ts
+++ b/lib/model-interfaces/idefics/index.ts
@@ -71,6 +71,7 @@ export class IdeficsInterface extends Construct {
         accessLogDestination: new apigateway.LogGroupLogDestination(logGroup),
         accessLogFormat: apigateway.AccessLogFormat.jsonWithStandardFields(),
       },
+      cloudWatchRole: true,
       binaryMediaTypes: ["*/*"],
       endpointConfiguration: {
         types: [apigateway.EndpointType.PRIVATE],


### PR DESCRIPTION

*Issue #, if available:*
Resolves: #412

*Description of changes:*
We configure the `RestApi` construct to add the necessary role automatically.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
