### PR TITLE
Correctly switch interface based on chat history and model capabilities

### DIFF
--- a/lib/user-interface/react-app/src/components/chatbot/chat-input-panel.tsx
+++ b/lib/user-interface/react-app/src/components/chatbot/chat-input-panel.tsx
@@ -190,6 +190,7 @@ export default function ChatInputPanel(props: ChatInputPanelProps) {
         })
         .catch((err) => console.log(err));
     };
+    // eslint-disable-next-line
   }, [props.session.id]);
 
   useEffect(() => {
@@ -298,11 +299,11 @@ export default function ChatInputPanel(props: ChatInputPanelProps) {
     const getSignedUrls = async () => {
       if (props.configuration?.files as ImageFile[]) {
         const files: ImageFile[] = [];
-        for await (const file of props.configuration!.files as ImageFile[]) {
+        for await (const file of props.configuration?.files ?? []) {
           const signedUrl = await getSignedUrl(file.key);
           files.push({
             ...file,
-            url: signedUrl as string,
+            url: signedUrl,
           });
         }
 
@@ -330,14 +331,18 @@ export default function ChatInputPanel(props: ChatInputPanelProps) {
       action: ChatBotAction.Run,
       modelInterface:
         (props.configuration.files && props.configuration.files.length > 0) ||
-        messageHistoryRef.current.filter((x) => x.metadata?.files !== undefined)
-          .length > 0
+        (messageHistoryRef.current.filter(
+          (x) => x.metadata?.files !== undefined
+        ).length > 0 &&
+          state.selectedModelMetadata?.inputModalities.includes(
+            ChabotInputModality.Image
+          ))
           ? "multimodal"
           : (state.selectedModelMetadata!.interface as ModelInterface),
       data: {
         mode: ChatBotMode.Chain,
         text: value,
-        files: props.configuration.files || [],
+        files: props.configuration.files ?? [],
         modelName: name,
         provider: provider,
         sessionId: props.session.id,
@@ -400,11 +405,11 @@ export default function ChatInputPanel(props: ChatInputPanelProps) {
     [ReadyState.UNINSTANTIATED]: "Uninstantiated",
   }[readyState];
 
-  const modelsOptions = OptionsHelper.getSelectOptionGroups(state.models || []);
+  const modelsOptions = OptionsHelper.getSelectOptionGroups(state.models ?? []);
 
   const workspaceOptions = [
     ...workspaceDefaultOptions,
-    ...OptionsHelper.getSelectOptions(state.workspaces || []),
+    ...OptionsHelper.getSelectOptions(state.workspaces ?? []),
   ];
 
   return (


### PR DESCRIPTION
*Issue #, if available:*
To allow for multimodal models, like Claude 3, to be used both for multimodal chat and RAG we selected which interface to use based on the presence of images in the user input or in the chat history. 
This  logic does not work if the user starts a multimodal chat (using images) and then switches to a text-only model, since we would still route the input to the multimodal interface which does not recognize the selected model

*Description of changes:*
We added a check to the existing conditions to verify that the selected model has IMAGE input modality support.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
