### PR TITLE
Improved Claude prompts for Langchain and fix to interface selection

### DIFF
--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/claude.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/claude.py
@@ -63,13 +63,16 @@ Question: {input}"""
         return prompt_template
 
     def get_condense_question_prompt(self):
-        template = """
+        template = """<conv>
 {chat_history}
+</conv>
 
-Human: Given the above conversation and a follow up input, rephrase the follow up input to be a standalone question, in the same language as the follow up input.
-Follow Up Input: {question}
+<followup>
+{question}
+</followup>
 
-Assistant:"""
+Given the conversation inside the tags <conv></conv>, rephrase the follow up question you find inside <followup></followup> to be a standalone question, in the same language as the follow up question.
+"""
 
         return PromptTemplate(
             input_variables=["chat_history", "question"],

--- a/lib/user-interface/react-app/src/components/chatbot/chat-input-panel.tsx
+++ b/lib/user-interface/react-app/src/components/chatbot/chat-input-panel.tsx
@@ -316,6 +316,17 @@ export default function ChatInputPanel(props: ChatInputPanelProps) {
     }
   }, [props.configuration]);
 
+  const hasImagesInChatHistory = function (): boolean {
+    return (
+      messageHistoryRef.current.filter(
+        (x) =>
+          x.type == ChatBotMessageType.Human &&
+          x.metadata?.files &&
+          (x.metadata.files as object[]).length > 0
+      ).length > 0
+    );
+  };
+
   const handleSendMessage = () => {
     if (!state.selectedModel) return;
     if (props.running) return;
@@ -331,9 +342,7 @@ export default function ChatInputPanel(props: ChatInputPanelProps) {
       action: ChatBotAction.Run,
       modelInterface:
         (props.configuration.files && props.configuration.files.length > 0) ||
-        (messageHistoryRef.current.filter(
-          (x) => x.metadata?.files !== undefined
-        ).length > 0 &&
+        (hasImagesInChatHistory() &&
           state.selectedModelMetadata?.inputModalities.includes(
             ChabotInputModality.Image
           ))
@@ -355,7 +364,7 @@ export default function ChatInputPanel(props: ChatInputPanelProps) {
         },
       },
     };
-
+    console.log(request);
     setState((state) => ({
       ...state,
       value: "",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- improvement to the condense prompt used by Langchain for the claude models. The new prompt uses xml tags to identify sections of the prompt and be more consistent in generating correct asnwers
- fix at the interface selection logic with improved checks on when to trigger the multimodal interface

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
