### PR TITLE
fix: missing link to schedule docs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -51,6 +51,7 @@ export default defineConfig({
           { text: 'Inference Script', link: '/documentation/inference-script' },
           { text: 'Document Retrieval', link: '/documentation/retriever' },
           { text: 'AppSync', link: '/documentation/appsync' },
+          { text: 'SageMaker Schedule', link: '/documentation/sagemaker-schedule' },
           { text: 'Security', link: '/documentation/vulnerability-scanning' },
           { text: 'Precautions', link: '/documentation/precautions' }
         ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add missing link to new docs page on sagemaker schedule


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
