### PR TITLE
Session History screen

### DIFF
--- a/lib/user-interface/react-app/src/app.tsx
+++ b/lib/user-interface/react-app/src/app.tsx
@@ -24,6 +24,7 @@ import WorkspacePane from "./pages/rag/workspace/workspace";
 import Workspaces from "./pages/rag/workspaces/workspaces";
 import Welcome from "./pages/welcome";
 import "./styles/app.scss";
+import SessionPage from "./pages/chatbot/sessions/sessions";
 
 function App() {
   const appContext = useContext(AppContext);
@@ -40,6 +41,7 @@ function App() {
             <Route path="/chatbot" element={<Outlet />}>
               <Route path="playground" element={<Playground />} />
               <Route path="playground/:sessionId" element={<Playground />} />
+              <Route path="sessions" element={<SessionPage />} />
               <Route path="multichat" element={<MultiChatPlayground />} />
               <Route path="models" element={<Models />} />
             </Route>

--- a/lib/user-interface/react-app/src/common/hooks/use-navigation-panel-state.ts
+++ b/lib/user-interface/react-app/src/common/hooks/use-navigation-panel-state.ts
@@ -11,6 +11,7 @@ export function useNavigationPanelState(): [
   );
 
   const onChange = (state: Partial<NavigationPanelState>) => {
+    console.log(state);
     setCurrentState(StorageHelper.setNavigationPanelState(state));
   };
 

--- a/lib/user-interface/react-app/src/components/base-app-layout.tsx
+++ b/lib/user-interface/react-app/src/components/base-app-layout.tsx
@@ -1,10 +1,14 @@
 import { AppLayout, AppLayoutProps } from "@cloudscape-design/components";
 import { useNavigationPanelState } from "../common/hooks/use-navigation-panel-state";
 import NavigationPanel from "./navigation-panel";
+import { ReactElement, useState } from "react";
 
-export default function BaseAppLayout(props: AppLayoutProps) {
+export default function BaseAppLayout(
+  props: AppLayoutProps & { info?: ReactElement }
+) {
   const [navigationPanelState, setNavigationPanelState] =
     useNavigationPanelState();
+  const [toolsOpen, setToolsOpen] = useState(false);
 
   return (
     <AppLayout
@@ -14,7 +18,10 @@ export default function BaseAppLayout(props: AppLayoutProps) {
       onNavigationChange={({ detail }) =>
         setNavigationPanelState({ collapsed: !detail.open })
       }
-      toolsHide={true}
+      toolsHide={props.info === undefined ? true : false}
+      tools={props.info}
+      toolsOpen={toolsOpen}
+      onToolsChange={({ detail }) => setToolsOpen(detail.open)}
       {...props}
     />
   );

--- a/lib/user-interface/react-app/src/components/chatbot/sessions.tsx
+++ b/lib/user-interface/react-app/src/components/chatbot/sessions.tsx
@@ -30,6 +30,7 @@ export default function Sessions(props: SessionsProps) {
   const [selectedItems, setSelectedItems] = useState<Session[]>([]);
   const [preferences, setPreferences] = useState({ pageSize: 20 });
   const [showModalDelete, setShowModalDelete] = useState(false);
+  const [deleteAllSessions, setDeleteAllSessions] = useState(false);
 
   const { items, collectionProps, paginationProps } = useCollection(sessions, {
     filtering: {
@@ -91,7 +92,6 @@ export default function Sessions(props: SessionsProps) {
 
   const deleteUserSessions = async () => {
     if (!appContext) return;
-    if (!confirm("Are you sure you want to delete all sessions?")) return;
 
     setIsLoading(true);
     const apiClient = new ApiClient(appContext);
@@ -124,6 +124,29 @@ export default function Sessions(props: SessionsProps) {
         {selectedItems.length == 1
           ? `session ${selectedItems[0].id}?`
           : `${selectedItems.length} sessions?`}
+      </Modal>
+      <Modal
+        onDismiss={() => setDeleteAllSessions(false)}
+        visible={deleteAllSessions}
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              {" "}
+              <Button
+                variant="link"
+                onClick={() => setDeleteAllSessions(false)}
+              >
+                Cancel
+              </Button>
+              <Button variant="primary" onClick={deleteUserSessions}>
+                Ok
+              </Button>
+            </SpaceBetween>{" "}
+          </Box>
+        }
+        header={"Delete all sessions"}
+      >
+        {`Do you want to delete ${sessions.length} sessions?`}
       </Modal>
       <Table
         {...collectionProps}
@@ -211,7 +234,7 @@ export default function Sessions(props: SessionsProps) {
                   iconAlt="Delete all sessions"
                   iconName="delete-marker"
                   variant="inline-link"
-                  onClick={() => deleteUserSessions()}
+                  onClick={() => setDeleteAllSessions(true)}
                 >
                   Delete all sessions
                 </Button>

--- a/lib/user-interface/react-app/src/components/chatbot/sessions.tsx
+++ b/lib/user-interface/react-app/src/components/chatbot/sessions.tsx
@@ -7,6 +7,7 @@ import {
   TableProps,
   Header,
   CollectionPreferences,
+  Modal,
 } from "@cloudscape-design/components";
 import { DateTime } from "luxon";
 import { useState, useEffect, useContext, useCallback } from "react";
@@ -28,6 +29,7 @@ export default function Sessions(props: SessionsProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [selectedItems, setSelectedItems] = useState<Session[]>([]);
   const [preferences, setPreferences] = useState({ pageSize: 20 });
+  const [showModalDelete, setShowModalDelete] = useState(false);
 
   const { items, collectionProps, paginationProps } = useCollection(sessions, {
     filtering: {
@@ -99,129 +101,157 @@ export default function Sessions(props: SessionsProps) {
   };
 
   return (
-    <Table
-      {...collectionProps}
-      variant="full-page"
-      items={items}
-      onSelectionChange={({ detail }) => {
-        console.log(detail);
-        setSelectedItems(detail.selectedItems);
-      }}
-      selectedItems={selectedItems}
-      selectionType="multi"
-      trackBy="id"
-      empty={
-        <Box margin={{ vertical: "xs" }} textAlign="center" color="inherit">
-          <SpaceBetween size="m">
-            <b>No sessions</b>
-          </SpaceBetween>
-        </Box>
-      }
-      ariaLabels={{
-        selectionGroupLabel: "Items selection",
-        allItemsSelectionLabel: ({ selectedItems }) =>
-          `${selectedItems.length} ${
-            selectedItems.length === 1 ? "item" : "items"
-          } selected`,
-        itemSelectionLabel: ({ selectedItems }, item) => item.title!, // eslint-disable-line @typescript-eslint/no-unused-vars
-      }}
-      pagination={<Pagination {...paginationProps} />}
-      loadingText="Loading history"
-      loading={isLoading}
-      resizableColumns
-      stickyHeader={true}
-      preferences={
-        <CollectionPreferences
-          onConfirm={({ detail }) =>
-            setPreferences({ pageSize: detail.pageSize ?? 20 })
-          }
-          title="Preferences"
-          confirmLabel="Confirm"
-          cancelLabel="Cancel"
-          preferences={preferences}
-          pageSizePreference={{
-            title: "Page size",
-            options: [
-              { value: 10, label: "10" },
-              { value: 20, label: "20" },
-              { value: 50, label: "50" },
-            ],
-          }}
-        />
-      }
-      header={
-        <Header
-          description="List of past sessions"
-          variant="awsui-h1-sticky"
-          actions={
-            <SpaceBetween direction="horizontal" size="m" alignItems="center">
-              <RouterButton
-                iconName="add-plus"
-                href={`/chatbot/playground/${uuidv4()}`}
-                variant="inline-link"
-              >
-                New session
-              </RouterButton>
-              <Button
-                iconAlt="Refresh list"
-                iconName="refresh"
-                variant="inline-link"
-                onClick={() => getSessions()}
-              >
-                Refresh
+    <>
+      <Modal
+        onDismiss={() => setShowModalDelete(false)}
+        visible={showModalDelete}
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              {" "}
+              <Button variant="link" onClick={() => setShowModalDelete(false)}>
+                Cancel
               </Button>
-              <Button
-                iconAlt="Delete"
-                iconName="remove"
-                variant="inline-link"
-                onClick={() => deleteSelectedSessions()}
-              >
-                Delete
+              <Button variant="primary" onClick={deleteSelectedSessions}>
+                Ok
               </Button>
-              <Button
-                iconAlt="Delete all sessions"
-                iconName="delete-marker"
-                variant="inline-link"
-                onClick={() => deleteUserSessions()}
-              >
-                Delete all sessions
-              </Button>
+            </SpaceBetween>{" "}
+          </Box>
+        }
+        header={"Delete session" + (selectedItems.length > 1 ? "s" : "")}
+      >
+        Do you want to delete{" "}
+        {selectedItems.length == 1
+          ? `session ${selectedItems[0].id}?`
+          : `${selectedItems.length} sessions?`}
+      </Modal>
+      <Table
+        {...collectionProps}
+        variant="full-page"
+        items={items}
+        onSelectionChange={({ detail }) => {
+          console.log(detail);
+          setSelectedItems(detail.selectedItems);
+        }}
+        selectedItems={selectedItems}
+        selectionType="multi"
+        trackBy="id"
+        empty={
+          <Box margin={{ vertical: "xs" }} textAlign="center" color="inherit">
+            <SpaceBetween size="m">
+              <b>No sessions</b>
             </SpaceBetween>
-          }
-        >
-          Session History
-        </Header>
-      }
-      columnDefinitions={
-        [
-          {
-            id: "title",
-            header: "Title",
-            sortingField: "title",
-            width: 800,
-            minWidth: 200,
-            cell: (e) => (
-              <Link to={`/chatbot/playground/${e.id}`}>{e.title}</Link>
-            ),
-            isRowHeader: true,
-          },
-          {
-            id: "startTime",
-            header: "Time",
-            sortingField: "startTime",
-            cell: (e: Session) =>
-              DateTime.fromISO(
-                new Date(e.startTime).toISOString()
-              ).toLocaleString(DateTime.DATETIME_SHORT),
-            sortingComparator: (a, b) => {
-              return (
-                new Date(b.startTime).getTime() -
-                new Date(a.startTime).getTime()
-              );
+          </Box>
+        }
+        ariaLabels={{
+          selectionGroupLabel: "Items selection",
+          allItemsSelectionLabel: ({ selectedItems }) =>
+            `${selectedItems.length} ${
+              selectedItems.length === 1 ? "item" : "items"
+            } selected`,
+          itemSelectionLabel: ({ selectedItems }, item) => item.title!, // eslint-disable-line @typescript-eslint/no-unused-vars
+        }}
+        pagination={<Pagination {...paginationProps} />}
+        loadingText="Loading history"
+        loading={isLoading}
+        resizableColumns
+        stickyHeader={true}
+        preferences={
+          <CollectionPreferences
+            onConfirm={({ detail }) =>
+              setPreferences({ pageSize: detail.pageSize ?? 20 })
+            }
+            title="Preferences"
+            confirmLabel="Confirm"
+            cancelLabel="Cancel"
+            preferences={preferences}
+            pageSizePreference={{
+              title: "Page size",
+              options: [
+                { value: 10, label: "10" },
+                { value: 20, label: "20" },
+                { value: 50, label: "50" },
+              ],
+            }}
+          />
+        }
+        header={
+          <Header
+            description="List of past sessions"
+            variant="awsui-h1-sticky"
+            actions={
+              <SpaceBetween direction="horizontal" size="m" alignItems="center">
+                <RouterButton
+                  iconName="add-plus"
+                  href={`/chatbot/playground/${uuidv4()}`}
+                  variant="inline-link"
+                >
+                  New session
+                </RouterButton>
+                <Button
+                  iconAlt="Refresh list"
+                  iconName="refresh"
+                  variant="inline-link"
+                  onClick={() => getSessions()}
+                >
+                  Refresh
+                </Button>
+                <Button
+                  disabled={selectedItems.length == 0}
+                  iconAlt="Delete"
+                  iconName="remove"
+                  variant="inline-link"
+                  onClick={() => {
+                    if (selectedItems.length > 0) setShowModalDelete(true);
+                  }}
+                >
+                  Delete
+                </Button>
+                <Button
+                  iconAlt="Delete all sessions"
+                  iconName="delete-marker"
+                  variant="inline-link"
+                  onClick={() => deleteUserSessions()}
+                >
+                  Delete all sessions
+                </Button>
+              </SpaceBetween>
+            }
+          >
+            Session History
+          </Header>
+        }
+        columnDefinitions={
+          [
+            {
+              id: "title",
+              header: "Title",
+              sortingField: "title",
+              width: 800,
+              minWidth: 200,
+              cell: (e) => (
+                <Link to={`/chatbot/playground/${e.id}`}>{e.title}</Link>
+              ),
+              isRowHeader: true,
             },
-          },
-        ] as TableProps.ColumnDefinition<Session>[]
-      }
-    />
+            {
+              id: "startTime",
+              header: "Time",
+              sortingField: "startTime",
+              cell: (e: Session) =>
+                DateTime.fromISO(
+                  new Date(e.startTime).toISOString()
+                ).toLocaleString(DateTime.DATETIME_SHORT),
+              sortingComparator: (a, b) => {
+                return (
+                  new Date(b.startTime).getTime() -
+                  new Date(a.startTime).getTime()
+                );
+              },
+            },
+          ] as TableProps.ColumnDefinition<Session>[]
+        }
+      />
+    </>
   );
 }

--- a/lib/user-interface/react-app/src/components/chatbot/sessions.tsx
+++ b/lib/user-interface/react-app/src/components/chatbot/sessions.tsx
@@ -69,7 +69,6 @@ export default function Sessions(props: SessionsProps) {
 
   useEffect(() => {
     if (!appContext) return;
-    //if (!props.toolsOpen) return;
 
     (async () => {
       setIsLoading(true);

--- a/lib/user-interface/react-app/src/components/chatbot/sessions.tsx
+++ b/lib/user-interface/react-app/src/components/chatbot/sessions.tsx
@@ -5,6 +5,7 @@ import {
   Pagination,
   Button,
   TableProps,
+  Header,
 } from "@cloudscape-design/components";
 import { DateTime } from "luxon";
 import { useState, useEffect, useContext, useCallback } from "react";
@@ -61,7 +62,7 @@ export default function Sessions(props: SessionsProps) {
 
   useEffect(() => {
     if (!appContext) return;
-    if (!props.toolsOpen) return;
+    //if (!props.toolsOpen) return;
 
     (async () => {
       setIsLoading(true);
@@ -92,100 +93,92 @@ export default function Sessions(props: SessionsProps) {
   };
 
   return (
-    <div style={{ padding: "0px 14px" }}>
-      <Table
-        {...collectionProps}
-        variant="embedded"
-        items={items}
-        pagination={<Pagination {...paginationProps} />}
-        loadingText="Loading history"
-        loading={isLoading}
-        resizableColumns
-        header={
-          <div style={{ paddingTop: "4px" }}>
-            <h2>History</h2>
-            <div>
-              <SpaceBetween direction="horizontal" size="m" alignItems="center">
-                <RouterButton
-                  iconName="add-plus"
-                  href={`/chatbot/playground/${uuidv4()}`}
-                  variant="inline-link"
-                >
-                  New session
-                </RouterButton>
-                <Button
-                  iconAlt="Refresh list"
-                  iconName="refresh"
-                  variant="inline-link"
-                  onClick={() => getSessions()}
-                >
-                  Refresh
-                </Button>
-                <Button
-                  iconAlt="Delete all sessions"
-                  iconName="delete-marker"
-                  variant="inline-link"
-                  onClick={() => deleteUserSessions()}
-                >
-                  Delete all sessions
-                </Button>
-              </SpaceBetween>
-            </div>
-          </div>
-        }
-        columnDefinitions={
-          [
-            {
-              id: "title",
-              header: "Title",
-              sortingField: "title",
-              cell: (e) => (
-                <Link to={`/chatbot/playground/${e.id}`}>{e.title}</Link>
-              ),
-              isRowHeader: true,
+    <Table
+      {...collectionProps}
+      variant="full-page"
+      items={items}
+      pagination={<Pagination {...paginationProps} />}
+      loadingText="Loading history"
+      loading={isLoading}
+      resizableColumns
+      header={
+        <Header
+          variant="awsui-h1-sticky"
+          actions={
+            <SpaceBetween direction="horizontal" size="m" alignItems="center">
+              <RouterButton
+                iconName="add-plus"
+                href={`/chatbot/playground/${uuidv4()}`}
+                variant="inline-link"
+              >
+                New session
+              </RouterButton>
+              <Button
+                iconAlt="Refresh list"
+                iconName="refresh"
+                variant="inline-link"
+                onClick={() => getSessions()}
+              >
+                Refresh
+              </Button>
+              <Button
+                iconAlt="Delete all sessions"
+                iconName="delete-marker"
+                variant="inline-link"
+                onClick={() => deleteUserSessions()}
+              >
+                Delete all sessions
+              </Button>
+            </SpaceBetween>
+          }
+        >
+          History
+        </Header>
+      }
+      columnDefinitions={
+        [
+          {
+            id: "title",
+            header: "Title",
+            sortingField: "title",
+            width: 800,
+            minWidth: 200,
+            cell: (e) => (
+              <Link to={`/chatbot/playground/${e.id}`}>{e.title}</Link>
+            ),
+            isRowHeader: true,
+          },
+          {
+            id: "startTime",
+            header: "Time",
+            sortingField: "startTime",
+            cell: (e: Session) =>
+              DateTime.fromISO(
+                new Date(e.startTime).toISOString()
+              ).toLocaleString(DateTime.DATETIME_SHORT),
+            sortingComparator: (a, b) => {
+              return (
+                new Date(b.startTime).getTime() -
+                new Date(a.startTime).getTime()
+              );
             },
-            {
-              id: "startTime",
-              header: "Time",
-              sortingField: "startTime",
-              cell: (e: Session) =>
-                DateTime.fromISO(
-                  new Date(e.startTime).toISOString()
-                ).toLocaleString(DateTime.DATETIME_SHORT),
-              sortingComparator: (a, b) => {
-                return (
-                  new Date(b.startTime).getTime() -
-                  new Date(a.startTime).getTime()
-                );
-              },
-            },
-            {
-              id: "open",
-              header: "Open",
-              cell: (item) => (
-                <RouterButton
-                  variant="inline-link"
-                  href={`/chatbot/playground/${item.id}`}
-                >
-                  Open
-                </RouterButton>
-              ),
-            },
-            {
-              id: "delete",
-              header: "Delete",
-              cell: (item) => (
-                <Button
-                  variant="inline-link"
-                  onClick={() => deleteSession(item.id)}
-                >
-                  Delete
-                </Button>
-              ),
-            },
-          ] as TableProps.ColumnDefinition<Session>[]
-        }
-      />
-    </div>
+          },
+          {
+            id: "delete",
+            width: 20,
+            header: "",
+            cell: (item) => (
+              <Button
+                variant="inline-icon"
+                iconName="remove"
+                onClick={() => deleteSession(item.id)}
+              >
+                Delete
+              </Button>
+            ),
+          },
+        ] as TableProps.ColumnDefinition<Session>[]
+      }
+    />
   );
 }

--- a/lib/user-interface/react-app/src/components/navigation-panel.tsx
+++ b/lib/user-interface/react-app/src/components/navigation-panel.tsx
@@ -32,6 +32,11 @@ export default function NavigationPanel() {
           },
           {
             type: "link",
+            text: "Sessions",
+            href: "/chatbot/sessions",
+          },
+          {
+            type: "link",
             text: "Models",
             href: "/chatbot/models",
           },

--- a/lib/user-interface/react-app/src/pages/chatbot/models/models.tsx
+++ b/lib/user-interface/react-app/src/pages/chatbot/models/models.tsx
@@ -1,9 +1,11 @@
 import {
   BreadcrumbGroup,
   Header,
+  HelpPanel,
   Pagination,
   PropertyFilter,
   Table,
+  Link,
 } from "@cloudscape-design/components";
 import useOnFollow from "../../../common/hooks/use-on-follow";
 import BaseAppLayout from "../../../components/base-app-layout";
@@ -119,6 +121,25 @@ export default function Models() {
           }
           pagination={<Pagination {...paginationProps} />}
         />
+      }
+      info={
+        <HelpPanel header={<Header variant="h3">Foundation Models</Header>}>
+          <p>
+            For Amazon Bedrock we display all models available in the selected
+            AWS Region.
+          </p>
+          <p>
+            You might need to request access to the models you want to use via
+            the Amazon Bedrock{" "}
+            <Link
+              external
+              href="https://console.aws.amazon.com/bedrock/home?#/modelaccess"
+            >
+              Model access
+            </Link>{" "}
+            page
+          </p>
+        </HelpPanel>
       }
     />
   );

--- a/lib/user-interface/react-app/src/pages/chatbot/playground/multi-chat-playground.tsx
+++ b/lib/user-interface/react-app/src/pages/chatbot/playground/multi-chat-playground.tsx
@@ -1,6 +1,38 @@
 import BaseAppLayout from "../../../components/base-app-layout";
 import MultiChat from "../../../components/chatbot/multi-chat";
+import { Header, HelpPanel } from "@cloudscape-design/components";
+import { Link } from "react-router-dom";
 
 export default function MultiChatPlayground() {
-  return <BaseAppLayout toolsHide={true} content={<MultiChat />} />;
+  return (
+    <BaseAppLayout
+      info={
+        <HelpPanel header={<Header variant="h3">Using the chat</Header>}>
+          <p>
+            The multi-chat playground allows user to interact with up to 4 LLM
+            and RAG <Link to="/rag/workspaces">workspaces</Link> combinations.
+          </p>
+          <h3>Settings</h3>
+          <p>
+            You can configure additional settings for the LLM via the setting
+            action at the bottom-right. You can change the Temperature and Top P
+            values to be used for the answer generation. You can also enable and
+            disable streaming mode for those models that support it (the setting
+            is ignored if the model does not support streaming). Turning on
+            Metadata displays additional information about the answer, such as
+            the prompts being used to interact with the LLM and the document
+            passages that might have been retrieved from the RAG storage.
+          </p>
+          <h3>Session history</h3>
+          <p>
+            All individual conversations are saved and can be later accessed via
+            the <Link to="/chatbot/sessions">Session</Link> in the navigation
+            bar. For example, if you have 3 chats, there will be 3 sessions
+            saved in the history.
+          </p>
+        </HelpPanel>
+      }
+      content={<MultiChat />}
+    />
+  );
 }

--- a/lib/user-interface/react-app/src/pages/chatbot/playground/playground.tsx
+++ b/lib/user-interface/react-app/src/pages/chatbot/playground/playground.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import BaseAppLayout from "../../../components/base-app-layout";
 import Chat from "../../../components/chatbot/chat";
-import Sessions from "../../../components/chatbot/sessions";
-import { useParams } from "react-router-dom";
+
+import { Link, useParams } from "react-router-dom";
+import { Header, HelpPanel } from "@cloudscape-design/components";
 
 export default function Playground() {
   const { sessionId } = useParams();
@@ -13,8 +14,18 @@ export default function Playground() {
       toolsHide={false}
       toolsOpen={toolsOpen}
       onToolsChange={({ detail }) => setToolsOpen(detail.open)}
-      tools={<Sessions toolsOpen={toolsOpen} />}
-      toolsWidth={500}
+      tools={
+        <HelpPanel header={<Header variant="h3">Using the chat</Header>}>
+          <div>
+            This chat playground allows user to interact with a chosen LLM and
+            optional RAG retriever. If you select a multimodal model, you can
+            also upload images to use in the conversation. All conversations are
+            saved and can be later accessed via the{" "}
+            <Link to="/chatbot/sessions">Session</Link> in the navigation bar.
+          </div>
+        </HelpPanel>
+      }
+      toolsWidth={300}
       content={<Chat sessionId={sessionId} />}
     />
   );

--- a/lib/user-interface/react-app/src/pages/chatbot/playground/playground.tsx
+++ b/lib/user-interface/react-app/src/pages/chatbot/playground/playground.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import BaseAppLayout from "../../../components/base-app-layout";
 import Chat from "../../../components/chatbot/chat";
 
@@ -7,14 +6,10 @@ import { Header, HelpPanel } from "@cloudscape-design/components";
 
 export default function Playground() {
   const { sessionId } = useParams();
-  const [toolsOpen, setToolsOpen] = useState(false);
 
   return (
     <BaseAppLayout
-      toolsHide={false}
-      toolsOpen={toolsOpen}
-      onToolsChange={({ detail }) => setToolsOpen(detail.open)}
-      tools={
+      info={
         <HelpPanel header={<Header variant="h3">Using the chat</Header>}>
           <p>
             This chat playground allows user to interact with a chosen LLM and

--- a/lib/user-interface/react-app/src/pages/chatbot/playground/playground.tsx
+++ b/lib/user-interface/react-app/src/pages/chatbot/playground/playground.tsx
@@ -16,13 +16,32 @@ export default function Playground() {
       onToolsChange={({ detail }) => setToolsOpen(detail.open)}
       tools={
         <HelpPanel header={<Header variant="h3">Using the chat</Header>}>
-          <div>
+          <p>
             This chat playground allows user to interact with a chosen LLM and
-            optional RAG retriever. If you select a multimodal model, you can
-            also upload images to use in the conversation. All conversations are
-            saved and can be later accessed via the{" "}
+            optional RAG retriever. You can create new RAG workspaces via the{" "}
+            <Link to="/rag/workspaces">Workspaces</Link> console.
+          </p>
+          <h3>Settings</h3>
+          <p>
+            You can configure additional settings for the LLM via the setting
+            action at the bottom-right. You can change the Temperature and Top P
+            values to be used for the answer generation. You can also enable and
+            disable streaming mode for those models that support it (the setting
+            is ignored if the model does not support streaming). Turning on
+            Metadata displays additional information about the answer, such as
+            the prompts being used to interact with the LLM and the document
+            passages that might have been retrieved from the RAG storage.
+          </p>
+          <h3>Multimodal chat</h3>
+          <p>
+            If you select a multimodal model (like Anthropic Claude 3), you can
+            upload images to use in the conversation.
+          </p>
+          <h3>Session history</h3>
+          <p>
+            All conversations are saved and can be later accessed via the{" "}
             <Link to="/chatbot/sessions">Session</Link> in the navigation bar.
-          </div>
+          </p>
         </HelpPanel>
       }
       toolsWidth={300}

--- a/lib/user-interface/react-app/src/pages/chatbot/sessions/sessions.tsx
+++ b/lib/user-interface/react-app/src/pages/chatbot/sessions/sessions.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import BaseAppLayout from "../../../components/base-app-layout";
+import Sessions from "../../../components/chatbot/sessions";
+import { BreadcrumbGroup } from "@cloudscape-design/components";
+import { CHATBOT_NAME } from "../../../common/constants";
+import useOnFollow from "../../../common/hooks/use-on-follow";
+
+export default function SessionPage() {
+  const [toolsOpen, setToolsOpen] = useState(false);
+  const onFollow = useOnFollow();
+
+  return (
+    <BaseAppLayout
+      contentType="table"
+      breadcrumbs={
+        <BreadcrumbGroup
+          onFollow={onFollow}
+          items={[
+            {
+              text: CHATBOT_NAME,
+              href: "/",
+            },
+            {
+              text: "Sessions",
+              href: "/chatbot/sessions",
+            },
+          ]}
+        />
+      }
+      content={<Sessions toolsOpen={true} />}
+    />
+  );
+}

--- a/lib/user-interface/react-app/src/pages/chatbot/sessions/sessions.tsx
+++ b/lib/user-interface/react-app/src/pages/chatbot/sessions/sessions.tsx
@@ -12,6 +12,8 @@ export default function SessionPage() {
   return (
     <BaseAppLayout
       contentType="table"
+      toolsOpen={toolsOpen}
+      onToolsChange={(e) => setToolsOpen(e.detail.open)}
       breadcrumbs={
         <BreadcrumbGroup
           onFollow={onFollow}

--- a/lib/user-interface/react-app/src/pages/rag/cross-encoders/cross-encoders.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/cross-encoders/cross-encoders.tsx
@@ -6,6 +6,7 @@ import {
   Form,
   FormField,
   Header,
+  HelpPanel,
   Link,
   Select,
   SelectProps,
@@ -352,6 +353,11 @@ export default function CrossEncoders() {
             )}
           </SpaceBetween>
         </ContentLayout>
+      }
+      info={
+        <HelpPanel header={<Header variant="h3">Cross-Encoders</Header>}>
+          <p>Cross-encoders are ...</p>
+        </HelpPanel>
       }
     />
   );

--- a/lib/user-interface/react-app/src/pages/rag/embeddings/embeddings.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/embeddings/embeddings.tsx
@@ -16,6 +16,7 @@ import {
   Multiselect,
   Toggle,
   Popover,
+  HelpPanel,
 } from "@cloudscape-design/components";
 import BaseAppLayout from "../../../components/base-app-layout";
 import { useContext, useEffect, useState } from "react";
@@ -151,7 +152,8 @@ export default function Embeddings() {
       return apiClient.embeddings.getEmbeddings(
         provider,
         name,
-        data.input.map((input) => input.trim()), "store"
+        data.input.map((input) => input.trim()),
+        "store"
       );
     });
 
@@ -427,6 +429,35 @@ export default function Embeddings() {
             )}
           </SpaceBetween>
         </ContentLayout>
+      }
+      info={
+        <HelpPanel header={<Header variant="h3">Embeddings</Header>}>
+          <p>
+            You can select one or more models and enter several text chunks.
+          </p>
+          <p>
+            Semantic similarity via{" "}
+            <Link
+              external
+              href="https://en.wikipedia.org/wiki/Cosine_similarity"
+            >
+              Cosine distance
+            </Link>{" "}
+            and{" "}
+            <Link
+              external
+              href="https://en.wikipedia.org/wiki/Norm_(mathematics)#Euclidean_norm"
+            >
+              L2 Norm (aka Euclidean norm)
+            </Link>{" "}
+            will be calculated and displayed in matrix format for an easy
+            comparison.
+          </p>
+          <p>
+            The intensity of the color is relative to the similarity: the darker
+            the color, the more similar the text chunks.
+          </p>
+        </HelpPanel>
       }
     />
   );

--- a/lib/user-interface/react-app/src/pages/rag/semantic-search/semantic-search.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/semantic-search/semantic-search.tsx
@@ -6,6 +6,7 @@ import {
   Form,
   FormField,
   Header,
+  HelpPanel,
   Select,
   SelectProps,
   SpaceBetween,
@@ -282,6 +283,11 @@ export default function SemanticSearch() {
             )}
           </SpaceBetween>
         </ContentLayout>
+      }
+      info={
+        <HelpPanel header={<Header variant="h3">Semantic search</Header>}>
+          <p>Search in the workspace for the given query.</p>
+        </HelpPanel>
       }
     />
   );

--- a/lib/user-interface/react-app/src/pages/rag/workspaces/workspaces.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/workspaces/workspaces.tsx
@@ -1,8 +1,13 @@
-import { BreadcrumbGroup } from "@cloudscape-design/components";
+import {
+  BreadcrumbGroup,
+  Header,
+  HelpPanel,
+} from "@cloudscape-design/components";
 import useOnFollow from "../../../common/hooks/use-on-follow";
 import WorkspacesTable from "./workspaces-table";
 import BaseAppLayout from "../../../components/base-app-layout";
 import { CHATBOT_NAME } from "../../../common/constants";
+import { Link } from "react-router-dom";
 
 export default function Workspaces() {
   const onFollow = useOnFollow();
@@ -30,6 +35,29 @@ export default function Workspaces() {
         />
       }
       content={<WorkspacesTable />}
+      info={
+        <HelpPanel header={<Header variant="h3">RAG Workspaces</Header>}>
+          <p>
+            RAG workspaces are built on top of a{" "}
+            <Link to="/rag/engines">RAG Engine</Link>.
+          </p>
+          <p>
+            {" "}
+            RAG engines can be modified at deployment time by running{" "}
+            <code
+              style={{
+                background: "#EEE",
+                padding: "3px",
+                fontSize: "1em",
+                borderRadius: "5px",
+              }}
+            >
+              npm&nbsp;run&nbsp;config
+            </code>
+            .
+          </p>
+        </HelpPanel>
+      }
     />
   );
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change provides  better visibility to Session History feature, and conform with CloudScape design guidelines. 
It introduces information panels on most screens and implements a framework to easily add information panels throughout the application. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

### Session History screen
![image](https://github.com/aws-samples/aws-genai-llm-chatbot/assets/38036163/e96b75c9-5e67-42f5-bd94-7438208d8dd3)

### Delete session
![image](https://github.com/aws-samples/aws-genai-llm-chatbot/assets/38036163/e7e99028-fde8-4f65-b50a-1447e8be488c)

### Delete sessions
![image](https://github.com/aws-samples/aws-genai-llm-chatbot/assets/38036163/88130df1-e9a2-45a5-86a3-b30d5bfde574)

### Settings
![image](https://github.com/aws-samples/aws-genai-llm-chatbot/assets/38036163/e8a798a1-f54d-4888-81f5-b8eee2caeffa)

