### PR TITLE
fix(readme): clarifying how to run the interface locally

### DIFF
--- a/lib/user-interface/react-app/README.md
+++ b/lib/user-interface/react-app/README.md
@@ -10,17 +10,30 @@ Follow instructions on the root folder README to deploy the cdk app.
 
 You will need the CloudFormation Output values displayed after completion in the following step.
 
-### Obtain environment configuration
+### Option 1: Obtain environment configuration
 
-Grab the `aws-exports.json` from the CloudFront distribution endpoint you obtained from the CDK Output, and save it into `./lib/user-interface/react-app/public/` folder.
+Grab the `aws-exports.json` from the CloudFront distribution endpoint you obtained from the CDK Output, and save it into `./lib/user-interface/react-app/public/` folder. Then run `npm run dev`.
 
-The URL is something like:
+For example:
 
-https://dxxxxxxxxxxxx.cloudfront.net/aws-exports.json
-
-### Build and run local dev server
-
+```bash
+cd lib/user-interface/react-app/public
+curl -O https://dxxxxxxxxxxxx.cloudfront.net/aws-exports.json
+cd ..
+npm run dev
 ```
+
+### Option 2: Set configuration as env variable
+
+```bash
+export AWS_PROJECT_REGION="..."
+export AWS_COGNITO_REGION="..."
+export AWS_USER_POOLS_ID="..."
+export AWS_USER_POOLS_WEB_CLIENT_ID="..."
+export API_DISTRIBUTION_DOMAIN_NAME="..."
+export RAG_ENABLED= 1 | 0
+export DEFAULT_EMBEDDINGS_MODEL = "..."
+export DEFAULT_CROSS_ENCODER_MODEL = "..."
 npm run build:dev
 npm run dev
 ```

--- a/lib/user-interface/react-app/README.md
+++ b/lib/user-interface/react-app/README.md
@@ -31,9 +31,9 @@ export AWS_COGNITO_REGION="..."
 export AWS_USER_POOLS_ID="..."
 export AWS_USER_POOLS_WEB_CLIENT_ID="..."
 export API_DISTRIBUTION_DOMAIN_NAME="..."
-export RAG_ENABLED= 1 | 0
-export DEFAULT_EMBEDDINGS_MODEL = "..."
-export DEFAULT_CROSS_ENCODER_MODEL = "..."
+export RAG_ENABLED=1|0
+export DEFAULT_EMBEDDINGS_MODEL="..."
+export DEFAULT_CROSS_ENCODER_MODEL="..."
 npm run build:dev
 npm run dev
 ```


### PR DESCRIPTION
*Issue #, if available:*

Fixes #159 

*Description of changes:*
Address the comments from @jtlz2

`npm run build:dev` only required to build the `aws-export.json` file from local variables. It must NOT be used when getting the configuration file from the deployment.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
