### PR TITLE
Improved development instructions

### DIFF
--- a/docs/guide/deploy.md
+++ b/docs/guide/deploy.md
@@ -48,23 +48,22 @@ You have:
 1. An [AWS account](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/)
 2. `AdministratorAccess` policy granted to your AWS account (for production, we recommend restricting access as needed)
 3. Both console and programmatic access
-4. [NodeJS 16 or 18](https://nodejs.org/en/download/) installed
+4. [NodeJS 18 or 20](https://nodejs.org/en/download/) installed
 
    - If you are using [`nvm`](https://github.com/nvm-sh/nvm) you can run the following before proceeding
    - ```
-     nvm install 16 && nvm use 16
+     nvm install 18 && nvm use 18
 
      or
 
-     nvm install 18 && nvm use 18
+     nvm install 20 && nvm use 20
      ```
 
 5. [AWS CLI](https://aws.amazon.com/cli/) installed and configured to use with your AWS account
-6. [Typescript 3.8+](https://www.typescriptlang.org/download) installed
-7. [AWS CDK CLI](https://docs.aws.amazon.com/cdk/latest/guide/getting_started.html) installed
-8. [Docker](https://docs.docker.com/get-docker/) installed
+6. [AWS CDK CLI](https://docs.aws.amazon.com/cdk/latest/guide/getting_started.html) installed
+7. [Docker](https://docs.docker.com/get-docker/) installed
    - N.B. [`buildx`](https://github.com/docker/buildx) is also required. For Windows and macOS `buildx` [is included](https://github.com/docker/buildx#windows-and-macos) in [Docker Desktop](https://docs.docker.com/desktop/)
-9. [Python 3+](https://www.python.org/downloads/) installed
+8. [Python 3+](https://www.python.org/downloads/) installed
 
 ## Deployment
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "aws-genai-llm-chatbot": "bin/aws-genai-llm-chatbot.js"
   },
   "scripts": {
-    "build": "npx @aws-amplify/cli codegen && tsc",
-    "watch": "tsc -w",
+    "build": "npx @aws-amplify/cli codegen && npx tsc",
+    "watch": "npx tsc -w",
     "cdk": "cdk",
     "gen": "npx @aws-amplify/cli codegen",
     "create": "node ./cli/magic.js config",


### PR DESCRIPTION
Instructions mentioned dependency on typescript 3.8+ but the code should install and use the right version of typescript (5+) already.

*Issue #, if available:*

*Description of changes:*
- updated `develop.md`
- replaced `tsc` with `npx tsc` to force the local version to be used in case the developer has a global version of typescript installed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
