### PR TITLE
Include UI in smoke-build GitHub action & add cdk synth check

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,7 @@ jobs:
         run: |
           npm install
           npm run build
+          npx cdk synth
       - name: Frontend
         working-directory: ./lib/user-interface/react-app
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,5 +10,12 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "18"
-      - run: npm install
-      - run: npm run build
+      - name: Backend
+        run: |
+          npm install
+          npm run build
+      - name: Frontend
+        working-directory: ./lib/user-interface/react-app
+        run: |
+          npm install
+          npm run build


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
npm commands for build checks were just being ran in the repository root, and would skip over the user-interface/react-app directory, allowing errors to slip through the review process. This PR adds build checks for the UI and adds a cdk synth command to serve as a temporary measure until the preferred e2e testing for cdk is ready.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
