### PR TITLE
feat: bedrock region expansion eu-west-3 & ap-southeast-2

### DIFF
--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -46,7 +46,9 @@ export enum SupportedRegion {
 export enum SupportedBedrockRegion {
   AP_NORTHEAST_1 = "ap-northeast-1",
   AP_SOUTHEAST_1 = "ap-southeast-1",
+  AP_SOUTHEAST_2 = "ap-southeast-2",
   EU_CENTRAL_1 = "eu-central-1",
+  EU_WEST_3 = "eu-west-3",
   US_EAST_1 = "us-east-1",
   US_WEST_2 = "us-west-2",
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
EU-WEST-3 Paris and AP-SOUTHEAST-2 Sydney now supported by Bedrock

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
