### PR TITLE
fix: logic for private website and add validation on config params

### DIFF
--- a/cli/magic-config.ts
+++ b/cli/magic-config.ts
@@ -72,6 +72,7 @@ const cfCountries = getCountryCodesAndNames();
 
 const iamRoleRegExp = RegExp(/arn:aws:iam::\d+:role\/[\w-_]+/);
 const acmCertRegExp = RegExp(/arn:aws:acm:[\w-_]+:\d+:certificate\/[\w-_]+/);
+const cfAcmCertRegExp = RegExp(/arn:aws:acm:us-east-1:\d+:certificate\/[\w-_]+/);
 const kendraIdRegExp = RegExp(/^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/);
 
 const embeddingModels = [
@@ -253,10 +254,20 @@ async function processCreateOptions(options: any): Promise<void> {
       type: "input",
       name: "certificate",
       validate(v: string) {
-        const valid = acmCertRegExp.test(v);
-        return (this as any).skipped || valid
-          ? true
-          : "You need to enter an ACM certificate arn";
+        if ((this as any).state.answers.privateWebsite)
+        {
+          const valid = acmCertRegExp.test(v);
+          return (this as any).skipped || valid
+            ? true
+            : "You need to enter an ACM certificate arn";
+        }
+        else
+        {
+          const valid = cfAcmCertRegExp.test(v);
+          return (this as any).skipped || valid
+            ? true
+            : "You need to enter an ACM certificate arn in us-east-1 for CF";
+        }
       },
       message(): string {
         if ((this as any).state.answers.customPublicDomain) {
@@ -292,7 +303,7 @@ async function processCreateOptions(options: any): Promise<void> {
       type: "confirm",
       name: "cfGeoRestrictEnable",
       message: "Do want to restrict access to the website (CF Distribution) to only a country or countries?",
-      initial: false,
+      initial: options.cfGeoRestrictEnable || false,
       skip(): boolean {
         return (this as any).state.answers.privateWebsite;
       },


### PR DESCRIPTION
*Issue #, if available:*

#450 

*Description of changes:*

ACM cert and domain name entries are required when selecting private website or when creating a public website with a custom domain. this change adds validation to those fields to make them required in those circumstances and does some additional validation to ensure a valid ACM ARN is supplied.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
