### PR TITLE
fix(chat message): added fallback rules for the document tab labels

### DIFF
--- a/lib/user-interface/react-app/src/components/chatbot/chat-message.tsx
+++ b/lib/user-interface/react-app/src/components/chatbot/chat-message.tsx
@@ -132,7 +132,10 @@ export default function ChatMessage(props: ChatMessageProps) {
                       ).map((p: any, i) => {
                         return {
                           id: `${i}`,
-                          label: p.metadata.path,
+                          label:
+                            p.metadata.path?.split("/").at(-1) ??
+                            p.metadata.title ??
+                            p.metadata.document_id.slice(-8),
                           content: (
                             <>
                               <Textarea


### PR DESCRIPTION
*Issue #, if available:*
Some documents (eg text docs) returned by RAG do not provide a `path` field in the metadata making the UI crash. 

*Description of changes:*
 added fallback rules for the document tab labels

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
