### PR TITLE
fix: add ability to set HF_token now required by Mistral models on HF

### DIFF
--- a/docs/documentation/model-requirements.md
+++ b/docs/documentation/model-requirements.md
@@ -19,6 +19,18 @@ Note:
 
 ![sample](./assets/enable-models.gif "AWS GenAI Chatbot")
 
+## HuggingFace Authentication
+
+Some models hosted on HuggingFace require an API key for access, for example MistralAI and Meta models have now changed to be gated behind accepting their EULA
+
+If you wish to continue using these models or access other models on HuggingFace which require authentication you can now supply this HF token as part of the installer.
+
+When enabling sagemaker models in the installer it will now ask you for a Secrets Manager Secret ARN containing the HF API token.
+
+You can read more about setting up access tokens on the [HF website](https://huggingface.co/docs/hub/en/security-tokens) Once you've got a token you may need to also navigate to a models page such as mistral7B to accept their terms before you can then use your token to access the model.
+
+The secret you would create in secrets manager would be a plain text secret containing just the HF token itself.
+
 ## Third-party models requirements
 
 You can also interact with external providers via their API, such as AI21 Labs, Cohere, OpenAI, etc.

--- a/lib/models/index.ts
+++ b/lib/models/index.ts
@@ -2,6 +2,7 @@ import * as cdk from "aws-cdk-lib";
 import * as ssm from "aws-cdk-lib/aws-ssm";
 import { Construct } from "constructs";
 import * as iam from "aws-cdk-lib/aws-iam";
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import { Shared } from "../shared";
 import {
   Modality,
@@ -34,6 +35,10 @@ export class Models extends Construct {
 
     const models: SageMakerModelEndpoint[] = [];
 
+    let hfTokenSecret: secretsmanager.Secret | undefined;
+    if (props.config.llms.huggingfaceApiSecretArn) {
+      hfTokenSecret = secretsmanager.Secret.fromSecretCompleteArn(this, 'HFTokenSecret', props.config.llms.huggingfaceApiSecretArn) as secretsmanager.Secret;
+    }
     if (
       props.config.llms?.sagemaker.includes(SupportedSageMakerModels.FalconLite)
     ) {
@@ -106,11 +111,12 @@ export class Models extends Construct {
             ),
           },
           container:
-            DeepLearningContainerImage.HUGGINGFACE_PYTORCH_TGI_INFERENCE_2_0_1_TGI1_1_0_GPU_PY39_CU118_UBUNTU20_04,
+            DeepLearningContainerImage.HUGGINGFACE_PYTORCH_TGI_INFERENCE_2_1_1_TGI2_0_0_GPU_PY310_CU121_UBUNTU22_04,
           instanceType: SageMakerInstanceType.ML_G5_2XLARGE,
           startupHealthCheckTimeoutInSeconds: 300,
           endpointName: MISTRAL_7B_ENDPOINT_NAME,
           environment: {
+            HF_TOKEN: hfTokenSecret?.secretValue.unsafeUnwrap().toString() || "",
             SM_NUM_GPUS: JSON.stringify(1),
             MAX_INPUT_LENGTH: JSON.stringify(2048),
             MAX_TOTAL_TOKENS: JSON.stringify(4096),
@@ -152,14 +158,12 @@ export class Models extends Construct {
               (subnet) => subnet.subnetId
             ),
           },
-          container: DeepLearningContainerImage.fromDeepLearningContainerImage(
-            "huggingface-pytorch-tgi-inference",
-            "2.1.1-tgi1.3.3-gpu-py310-cu121-ubuntu20.04"
-          ),
+          container: DeepLearningContainerImage.HUGGINGFACE_PYTORCH_TGI_INFERENCE_2_1_1_TGI2_0_0_GPU_PY310_CU121_UBUNTU22_04,
           instanceType: SageMakerInstanceType.ML_G5_2XLARGE,
           startupHealthCheckTimeoutInSeconds: 300,
           endpointName: MISTRAL_7B_INSTRUCT2_ENDPOINT_NAME,
           environment: {
+            HF_TOKEN: hfTokenSecret?.secretValue.unsafeUnwrap().toString() || "",
             SM_NUM_GPUS: JSON.stringify(1),
             MAX_INPUT_LENGTH: JSON.stringify(2048),
             MAX_TOTAL_TOKENS: JSON.stringify(4096),
@@ -205,14 +209,12 @@ export class Models extends Construct {
               (subnet) => subnet.subnetId
             ),
           },
-          container: DeepLearningContainerImage.fromDeepLearningContainerImage(
-            "huggingface-pytorch-tgi-inference",
-            "2.1.1-tgi1.3.3-gpu-py310-cu121-ubuntu20.04"
-          ),
+          container: DeepLearningContainerImage.HUGGINGFACE_PYTORCH_TGI_INFERENCE_2_1_1_TGI2_0_0_GPU_PY310_CU121_UBUNTU22_04,
           instanceType: SageMakerInstanceType.ML_G5_48XLARGE,
           startupHealthCheckTimeoutInSeconds: 300,
           endpointName: MISTRAL_8x7B_INSTRUCT2_ENDPOINT_NAME,
           environment: {
+            HF_TOKEN: hfTokenSecret?.secretValue.unsafeUnwrap().toString() || "",
             SM_NUM_GPUS: JSON.stringify(8),
             MAX_INPUT_LENGTH: JSON.stringify(24576),
             MAX_TOTAL_TOKENS: JSON.stringify(32768),

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -88,6 +88,7 @@ export interface SystemConfig {
   };
   llms: {
     sagemaker: SupportedSageMakerModels[];
+    huggingfaceApiSecretArn?: string;
     sagemakerSchedule?: {
       enabled?: boolean;
       timezonePicker?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-cdk/aws-apigatewayv2-authorizers-alpha": "^2.114.1-alpha.0",
         "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.114.1-alpha.0",
         "@aws-cdk/aws-cognito-identitypool-alpha": "^2.114.1-alpha.0",
-        "@cdklabs/generative-ai-cdk-constructs": "^0.1.50",
+        "@cdklabs/generative-ai-cdk-constructs": "^0.1.122",
         "aws-cdk-lib": "2.126.0",
         "cdk-nag": "2.27.170",
         "commander": "^11.0.0",
@@ -888,27 +888,39 @@
       }
     },
     "node_modules/@cdklabs/generative-ai-cdk-constructs": {
-      "version": "0.1.50",
-      "resolved": "https://registry.npmjs.org/@cdklabs/generative-ai-cdk-constructs/-/generative-ai-cdk-constructs-0.1.50.tgz",
-      "integrity": "sha512-YcocXwNoBXiz8p9ByYmNbuNmT8ih13efFKKV2x62pdTT2YnUttrliQRfxJPWI1E0EW+WH5xR93Ww9DzI048FUA==",
+      "version": "0.1.122",
+      "resolved": "https://registry.npmjs.org/@cdklabs/generative-ai-cdk-constructs/-/generative-ai-cdk-constructs-0.1.122.tgz",
+      "integrity": "sha512-PiT/DFda+zqqR+KU8Z+rTbV7zkHpM3Tn9rtuJqXDbbUF77y5ITGCPgiAjtCzKJ38bNQA0I+V/QZLWTv34CT52g==",
+      "bundleDependencies": [
+        "deepmerge"
+      ],
       "dependencies": {
-        "cdk-nag": "^2.28.25"
+        "cdk-nag": "^2.28.92",
+        "deepmerge": "^4.3.1"
       },
       "engines": {
         "node": ">= 18.12.0 <= 20.x"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.116.0",
+        "aws-cdk-lib": "^2.122.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@cdklabs/generative-ai-cdk-constructs/node_modules/cdk-nag": {
-      "version": "2.28.26",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.28.26.tgz",
-      "integrity": "sha512-UvqK+Mkt/aamcyRE2jxW4Y9y7Q8dnyVHmz9dEXR2fnv3cXuuNxo9uPz63Q/+VaQWuk/I6X0+QWUQGfj+Ao4nEg==",
+      "version": "2.28.94",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.28.94.tgz",
+      "integrity": "sha512-Q+vq+26CBna3dlEMmilZi/+Me2dkEhFm9CUEWMy5z2A2JAYQ83cq8KxWYlgeuSCXwr2yZkc8veV215gu3m5nKQ==",
       "peerDependencies": {
         "aws-cdk-lib": "^2.116.0",
         "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@cdklabs/generative-ai-cdk-constructs/node_modules/deepmerge": {
+      "version": "4.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@aws-cdk/aws-apigatewayv2-authorizers-alpha": "^2.114.1-alpha.0",
     "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.114.1-alpha.0",
     "@aws-cdk/aws-cognito-identitypool-alpha": "^2.114.1-alpha.0",
-    "@cdklabs/generative-ai-cdk-constructs": "^0.1.50",
+    "@cdklabs/generative-ai-cdk-constructs": "^0.1.122",
     "aws-cdk-lib": "2.126.0",
     "cdk-nag": "2.27.170",
     "commander": "^11.0.0",


### PR DESCRIPTION
*Issue #, if available:*

#461 

*Description of changes:*

As per issue, previously working Mistral models hosted via Sagemaker from HuggingFace are now broken and failing to start.

This is resolved by adding a feature to pass a now required HF_Token parameter to the model definition.

Required to update container runtimes for Mistral models to the latest that have proper support for HF_TOKEN. This also required bumping generative AI constructs to latest in order to be able to reference latest containers.

Have tested the changes and works as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
