### PR TITLE
fix: Added validation for filenames having comma

### DIFF
--- a/lib/user-interface/react-app/src/pages/rag/add-data/data-file-upload.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/add-data/data-file-upload.tsx
@@ -76,8 +76,10 @@ export default function DataFileUpload(props: DataFileUploadProps) {
     for (let i = 0; i < files.length; i++) {
       const file = files[i];
       const fileExtension = file.name.split(".").pop()?.toLowerCase();
-
-      if (!fileExtensions.has(`.${fileExtension}`)) {
+      const fileName = file.name;
+      if (fileName.includes(",")) {
+        errors[i] = "File name cannot contain a comma";
+      } else if (!fileExtensions.has(`.${fileExtension}`)) {
         errors[i] = "Format not supported";
       } else if (file.size > 1000 * 1000 * 100) {
         errors[i] = "File size is too large, max 100MB";


### PR DESCRIPTION
*Issue #452 *

*Description of changes:* Added validation so that filenames having comma cannot be uploaded. We are using comma as a separator later in the code and hence the upload fails if the file name has comma in it. This validation will ensure that filenames having comma are not allowed to be uploaded.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
