### PR TITLE
fix: website crawler limited to only 1 page crawl

### DIFF
--- a/lib/shared/layers/python-sdk/python/genai_core/documents.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/documents.py
@@ -485,6 +485,7 @@ def _process_document(
 
             try:
                 urls_to_crawl = genai_core.websites.extract_urls_from_sitemap(path)
+                limit = min(limit, len(urls_to_crawl))
 
                 if len(urls_to_crawl) == 0:
                     set_status(workspace_id, document_id, "error")
@@ -512,7 +513,7 @@ def _process_document(
                     "priority_queue": priority_queue,
                     "processed_urls": [],
                     "follow_links": follow_links,
-                    "limit": min(limit, len(urls_to_crawl)),
+                    "limit": limit,
                     "done": False,
                 },
                 cls=genai_core.utils.json.CustomEncoder,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Previously an error in logic always resulted in only a single page crawl ignoring links and limit set in GUI always defaulting to 1 as urls_to_crawl only contains multiple values when sitemap option is used. Now limit works correctly in both modes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
