### PR TITLE
fix: cli only show kendra existing index if kendra rag enabled

### DIFF
--- a/cli/magic-config.ts
+++ b/cli/magic-config.ts
@@ -630,7 +630,10 @@ async function processCreateOptions(options: any): Promise<void> {
           options.kendraExternal.length > 0) ||
         false,
       skip(): boolean {
-        return !(this as any).state.answers.enableRag;
+        if (!(this as any).state.answers.enableRag){
+          return true;
+        }
+        return !(this as any).state.answers.ragsToEnable.includes("kendra");
       },
     },
   ];


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

just a small logic fix to only show adding kendra existing index, if kendra rag enabled

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
