### PR TITLE
Let workspace private and personal by default for all user

### DIFF
--- a/lib/chatbot-api/rest-api.ts
+++ b/lib/chatbot-api/rest-api.ts
@@ -74,6 +74,10 @@ export class ApiResolvers extends Construct {
             props.ragEngines?.workspacesTable.tableName ?? "",
           WORKSPACES_BY_OBJECT_TYPE_INDEX_NAME:
             props.ragEngines?.workspacesByObjectTypeIndexName ?? "",
+          WORKSPACES_POLICY_TABLE_NAME:
+              props.ragEngines?.workspacesPolicyTable.tableName ?? "",
+          WORKSPACES_POLICY_BY_WORKSPACE_ID_INDEX_NAME:
+              props.ragEngines?.workspacesPolicyByWorkspaceIdIndexName ?? "",
           DOCUMENTS_TABLE_NAME:
             props.ragEngines?.documentsTable.tableName ?? "",
           DOCUMENTS_BY_COMPOUND_KEY_INDEX_NAME:
@@ -126,6 +130,10 @@ export class ApiResolvers extends Construct {
         props.ragEngines?.dataImport.rssIngestorFunction?.grantInvoke(
           apiHandler
         );
+      }
+
+      if (props.ragEngines?.workspacesPolicyTable) {
+        props.ragEngines.workspacesPolicyTable.grantReadWriteData(apiHandler);
       }
 
       if (props.ragEngines?.auroraPgVector) {

--- a/lib/chatbot-api/schema/schema.graphql
+++ b/lib/chatbot-api/schema/schema.graphql
@@ -3,6 +3,7 @@
 input CreateWorkspaceAuroraInput {
   name: String!
   kind: String!
+  isPublic: Boolean!
   embeddingsModelProvider: String!
   embeddingsModelName: String!
   crossEncoderModelProvider: String!
@@ -19,6 +20,7 @@ input CreateWorkspaceAuroraInput {
 input CreateWorkspaceKendraInput {
   name: String!
   kind: String!
+  isPublic: Boolean!
   kendraIndexId: String!
   useAllData: Boolean!
 }
@@ -26,6 +28,7 @@ input CreateWorkspaceKendraInput {
 input CreateWorkspaceOpenSearchInput {
   name: String!
   kind: String!
+  isPublic: Boolean!
   embeddingsModelProvider: String!
   embeddingsModelName: String!
   crossEncoderModelProvider: String!
@@ -266,6 +269,7 @@ input WebsiteInput {
 type Workspace @aws_cognito_user_pools {
   id: String!
   name: String!
+  isPublic: Boolean
   formatVersion: Int
   engine: String!
   status: String
@@ -291,6 +295,8 @@ type Workspace @aws_cognito_user_pools {
   kendraUseAllData: Boolean
   createdAt: AWSDateTime!
   updatedAt: AWSDateTime!
+  is_writable: Boolean
+  is_owner: Boolean
 }
 
 type Channel @aws_iam @aws_cognito_user_pools {

--- a/lib/rag-engines/index.ts
+++ b/lib/rag-engines/index.ts
@@ -28,6 +28,8 @@ export class RagEngines extends Construct {
   public readonly documentsTable: dynamodb.Table;
   public readonly workspacesTable: dynamodb.Table;
   public readonly workspacesByObjectTypeIndexName: string;
+  public readonly workspacesPolicyTable: dynamodb.Table;
+  public readonly workspacesPolicyByWorkspaceIdIndexName: string;
   public readonly documentsByCompountKeyIndexName: string;
   public readonly documentsByStatusIndexName: string;
   public readonly fileImportWorkflow?: sfn.StateMachine;
@@ -110,6 +112,8 @@ export class RagEngines extends Construct {
     this.processingBucket = dataImport.processingBucket;
     this.workspacesTable = tables.workspacesTable;
     this.documentsTable = tables.documentsTable;
+    this.workspacesPolicyTable = tables.workspacesPolicyTable;
+    this.workspacesPolicyByWorkspaceIdIndexName = tables.workspacesPolicyByWorkspaceIdIndexName;
     this.workspacesByObjectTypeIndexName =
       tables.workspacesByObjectTypeIndexName;
     this.documentsByCompountKeyIndexName =

--- a/lib/rag-engines/rag-dynamodb-tables/index.ts
+++ b/lib/rag-engines/rag-dynamodb-tables/index.ts
@@ -4,9 +4,12 @@ import { Construct } from "constructs";
 
 export class RagDynamoDBTables extends Construct {
   public readonly workspacesTable: dynamodb.Table;
+  public readonly workspacesPolicyTable: dynamodb.Table;
   public readonly documentsTable: dynamodb.Table;
   public readonly workspacesByObjectTypeIndexName: string =
     "by_object_type_idx";
+  public readonly workspacesPolicyByWorkspaceIdIndexName: string =
+      "by_workspace_idx";
   public readonly documentsByCompoundKeyIndexName: string =
     "by_compound_key_idx";
   public readonly documentsByStatusIndexName: string = "by_status_idx";
@@ -39,6 +42,29 @@ export class RagDynamoDBTables extends Construct {
         name: "created_at",
         type: dynamodb.AttributeType.STRING,
       },
+    });
+
+    const workspacesPolicyTable = new dynamodb.Table(this, "WorkspacesPolicy", {
+      partitionKey: {
+        name: "pk",
+        type: dynamodb.AttributeType.STRING,
+      },
+      sortKey: {
+        name: "sk",
+        type: dynamodb.AttributeType.STRING,
+      },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      pointInTimeRecovery: true,
+    });
+
+    workspacesPolicyTable.addGlobalSecondaryIndex({
+      indexName: this.workspacesPolicyByWorkspaceIdIndexName,
+      partitionKey: {
+        name: "workspace_id",
+        type: dynamodb.AttributeType.STRING,
+      }
     });
 
     const documentsTable = new dynamodb.Table(this, "Documents", {
@@ -81,6 +107,7 @@ export class RagDynamoDBTables extends Construct {
     });
 
     this.workspacesTable = workspacesTable;
+    this.workspacesPolicyTable = workspacesPolicyTable;
     this.documentsTable = documentsTable;
   }
 }

--- a/lib/user-interface/react-app/src/common/api-client/workspaces-client.ts
+++ b/lib/user-interface/react-app/src/common/api-client/workspaces-client.ts
@@ -63,6 +63,7 @@ export class WorkspacesClient {
     chunkingStrategy: string;
     chunkSize: number;
     chunkOverlap: number;
+    isPublic: boolean;
   }): Promise<GraphQLResult<GraphQLQuery<CreateAuroraWorkspaceMutation>>> {
     const result = API.graphql<GraphQLQuery<CreateAuroraWorkspaceMutation>>({
       query: createAuroraWorkspace,
@@ -84,6 +85,7 @@ export class WorkspacesClient {
     chunkingStrategy: string;
     chunkSize: number;
     chunkOverlap: number;
+    isPublic: boolean;
   }): Promise<GraphQLResult<GraphQLQuery<CreateOpenSearchWorkspaceMutation>>> {
     const result = API.graphql<GraphQLQuery<CreateOpenSearchWorkspaceMutation>>(
       {
@@ -100,6 +102,7 @@ export class WorkspacesClient {
     name: string;
     kendraIndexId: string;
     useAllData: boolean;
+    isPublic: boolean;
   }): Promise<GraphQLResult<GraphQLQuery<CreateKendraWorkspaceMutation>>> {
     const result = API.graphql<GraphQLQuery<CreateKendraWorkspaceMutation>>({
       query: createKendraWorkspace,

--- a/lib/user-interface/react-app/src/common/types.ts
+++ b/lib/user-interface/react-app/src/common/types.ts
@@ -71,6 +71,7 @@ export interface AuroraWorkspaceCreateInput {
   hybridSearch: boolean;
   chunkSize: number;
   chunkOverlap: number;
+  isPublic: boolean;
 }
 
 export interface OpenSearchWorkspaceCreateInput {
@@ -81,10 +82,12 @@ export interface OpenSearchWorkspaceCreateInput {
   hybridSearch: boolean;
   chunkSize: number;
   chunkOverlap: number;
+  isPublic: boolean;
 }
 
 export interface KendraWorkspaceCreateInput {
   name: string;
   kendraIndex: SelectProps.Option | null;
   useAllData: boolean;
+  isPublic: boolean;
 }

--- a/lib/user-interface/react-app/src/pages/rag/create-workspace/aurora-form.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/create-workspace/aurora-form.tsx
@@ -52,6 +52,17 @@ export default function AuroraForm(props: AuroraFormProps) {
           />
         </FormField>
 
+        <FormField label="Public Access" errorText={props.errors.isPublic}>
+          <Toggle
+              disabled={props.submitting}
+              checked={props.data.isPublic}
+              onChange={({ detail: { checked } }) =>
+                  props.onChange({ isPublic: checked })
+              }
+          >
+          </Toggle>
+        </FormField>
+
         <EmbeddingSelector
           errors={props.errors}
           submitting={props.submitting}

--- a/lib/user-interface/react-app/src/pages/rag/create-workspace/create-workspace-aurora.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/create-workspace/create-workspace-aurora.tsx
@@ -37,6 +37,7 @@ const defaults: AuroraWorkspaceCreateInput = {
   hybridSearch: true,
   chunkSize: 1000,
   chunkOverlap: 200,
+  isPublic: false
 };
 
 export default function CreateWorkspaceAurora() {
@@ -147,6 +148,7 @@ export default function CreateWorkspaceAurora() {
         chunkingStrategy: "recursive",
         chunkSize: data.chunkSize,
         chunkOverlap: data.chunkOverlap,
+        isPublic: data.isPublic
       });
 
       navigate(`/rag/workspaces/${result.data?.createAuroraWorkspace.id}`);

--- a/lib/user-interface/react-app/src/pages/rag/create-workspace/create-workspace-kendra.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/create-workspace/create-workspace-kendra.tsx
@@ -14,6 +14,7 @@ const defaults: KendraWorkspaceCreateInput = {
   name: "",
   kendraIndex: null,
   useAllData: false,
+  isPublic: false
 };
 
 export default function CreateWorkspaceKendra() {
@@ -63,6 +64,7 @@ export default function CreateWorkspaceKendra() {
         name: data.name.trim(),
         kendraIndexId: data.kendraIndex?.value ?? "",
         useAllData: data.useAllData,
+        isPublic: data.isPublic
       });
 
       navigate("/rag/workspaces");

--- a/lib/user-interface/react-app/src/pages/rag/create-workspace/create-workspace-opensearch.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/create-workspace/create-workspace-opensearch.tsx
@@ -20,6 +20,7 @@ const defaults: OpenSearchWorkspaceCreateInput = {
   hybridSearch: true,
   chunkSize: 1000,
   chunkOverlap: 200,
+  isPublic: false
 };
 
 export default function CreateWorkspaceOpenSearch() {
@@ -117,6 +118,7 @@ export default function CreateWorkspaceOpenSearch() {
         chunkingStrategy: "recursive",
         chunkSize: data.chunkSize,
         chunkOverlap: data.chunkOverlap,
+        isPublic: data.isPublic
       });
 
       navigate("/rag/workspaces");

--- a/lib/user-interface/react-app/src/pages/rag/create-workspace/kendra-form.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/create-workspace/kendra-form.tsx
@@ -82,6 +82,16 @@ export default function KendraForm(props: KendraFormProps) {
             }
           />
         </FormField>
+        <FormField label="Public Access" errorText={props.errors.isPublic}>
+          <Toggle
+              disabled={props.submitting}
+              checked={props.data.isPublic}
+              onChange={({ detail: { checked } }) =>
+                  props.onChange({ isPublic: checked })
+              }
+          >
+          </Toggle>
+        </FormField>
         <FormField label="Kendra Index" errorText={props.errors.kendraIndex}>
           <Select
             disabled={props.submitting}

--- a/lib/user-interface/react-app/src/pages/rag/create-workspace/opensearch-form.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/create-workspace/opensearch-form.tsx
@@ -5,7 +5,7 @@ import {
   SpaceBetween,
   FormField,
   Input,
-  ExpandableSection,
+  ExpandableSection, Toggle,
 } from "@cloudscape-design/components";
 import EmbeddingSelector from "./embeddings-selector-field";
 import { CrossEncoderSelectorField } from "./cross-encoder-selector-field";
@@ -43,6 +43,16 @@ export function OpenSearchForm(props: OpenSearchFormProps) {
               props.onChange({ name: value })
             }
           />
+        </FormField>
+        <FormField label="Public Access" errorText={props.errors.isPublic}>
+          <Toggle
+              disabled={props.submitting}
+              checked={props.data.isPublic}
+              onChange={({ detail: { checked } }) =>
+                  props.onChange({ isPublic: checked })
+              }
+          >
+          </Toggle>
         </FormField>
         <EmbeddingSelector
           submitting={props.submitting}

--- a/lib/user-interface/react-app/src/pages/rag/workspace/documents-tab.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/workspace/documents-tab.tsx
@@ -13,10 +13,10 @@ import { AppContext } from "../../../common/app-context";
 import { ApiClient } from "../../../common/api-client/api-client";
 import { getColumnDefinition } from "./columns";
 import { Utils } from "../../../common/utils";
-import { DocumentsResult } from "../../../API";
+import {DocumentsResult, Workspace} from "../../../API";
 
 export interface DocumentsTabProps {
-  workspaceId?: string;
+  workspace: Workspace;
   documentType: RagDocumentType;
 }
 
@@ -29,14 +29,14 @@ export default function DocumentsTab(props: DocumentsTabProps) {
   const getDocuments = useCallback(
     async (params: { lastDocumentId?: string; pageIndex?: number }) => {
       if (!appContext) return;
-      if (!props.workspaceId) return;
+      if (!props.workspace.id) return;
 
       setLoading(true);
 
       const apiClient = new ApiClient(appContext);
       try {
         const result = await apiClient.documents.getDocuments(
-          props.workspaceId,
+          props.workspace.id,
           props.documentType,
           params?.lastDocumentId
         );
@@ -65,7 +65,7 @@ export default function DocumentsTab(props: DocumentsTabProps) {
 
       setLoading(false);
     },
-    [appContext, props.documentType, props.workspaceId]
+    [appContext, props.documentType, props.workspace.id]
   );
 
   useEffect(() => {
@@ -104,6 +104,7 @@ export default function DocumentsTab(props: DocumentsTabProps) {
   const typeTitleStr = ragDocumentTypeToTitleString(props.documentType);
 
   const columnDefinitions = getColumnDefinition(props.documentType);
+  const isWritableWorkspace = props.workspace?.is_writable ?? false
 
   return (
     <Table
@@ -116,8 +117,8 @@ export default function DocumentsTab(props: DocumentsTabProps) {
           actions={
             <SpaceBetween direction="horizontal" size="xs">
               <Button iconName="refresh" onClick={refreshPage} />
-              <RouterButton
-                href={`/rag/workspaces/add-data?workspaceId=${props.workspaceId}&tab=${props.documentType}`}
+              <RouterButton disabled={!isWritableWorkspace}
+                href={`/rag/workspaces/add-data?workspaceId=${props.workspace.id}&tab=${props.documentType}`}
               >
                 {typeAddStr}
               </RouterButton>
@@ -131,7 +132,7 @@ export default function DocumentsTab(props: DocumentsTabProps) {
       empty={
         <TableEmptyState
           resourceName={typeStr}
-          createHref={`/rag/workspaces/add-data?workspaceId=${props.workspaceId}&tab=${props.documentType}`}
+          createHref={`/rag/workspaces/add-data?workspaceId=${props.workspace.id}&tab=${props.documentType}`}
           createText={typeAddStr}
         />
       }

--- a/lib/user-interface/react-app/src/pages/rag/workspace/workspace.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/workspace/workspace.tsx
@@ -22,6 +22,7 @@ import OpenSearchWorkspaceSettings from "./open-search-workspace-settings";
 import KendraWorkspaceSettings from "./kendra-workspace-settings";
 import { CHATBOT_NAME } from "../../../common/constants";
 import { Workspace } from "../../../API";
+import Badge from "@cloudscape-design/components/badge";
 
 export default function WorkspacePane() {
   const appContext = useContext(AppContext);
@@ -60,6 +61,8 @@ export default function WorkspacePane() {
   const disabledTabs =
     workspace?.engine === "kendra" ? ["qna", "website", "rssfeed"] : [];
 
+  const isWritableWorkspace = workspace?.is_writable ?? false
+
   return (
     <BaseAppLayout
       contentType="cards"
@@ -94,36 +97,37 @@ export default function WorkspacePane() {
               actions={
                 <SpaceBetween direction="horizontal" size="xs">
                   <RouterButton
-                    href={`/rag/semantic-search?workspaceId=${workspaceId}`}
+                    href={`/rag/semantic-search?workspaceId=${workspace?.id}`}
                   >
                     Semantic search
                   </RouterButton>
                   <RouterButtonDropdown
+                    disabled={!isWritableWorkspace}
                     items={[
                       {
                         id: "upload-file",
                         text: "Upload files",
-                        href: `/rag/workspaces/add-data?tab=file&workspaceId=${workspaceId}`,
+                        href: `/rag/workspaces/add-data?tab=file&workspaceId=${workspace?.id}`,
                       },
                       {
                         id: "add-text",
                         text: "Add texts",
-                        href: `/rag/workspaces/add-data?tab=text&workspaceId=${workspaceId}`,
+                        href: `/rag/workspaces/add-data?tab=text&workspaceId=${workspace?.id}`,
                       },
                       {
                         id: "add-qna",
                         text: "Add Q&A",
-                        href: `/rag/workspaces/add-data?tab=qna&workspaceId=${workspaceId}`,
+                        href: `/rag/workspaces/add-data?tab=qna&workspaceId=${workspace?.id}`,
                       },
                       {
                         id: "crawl-website",
                         text: "Crawl website",
-                        href: `/rag/workspaces/add-data?tab=website&workspaceId=${workspaceId}`,
+                        href: `/rag/workspaces/add-data?tab=website&workspaceId=${workspace?.id}`,
                       },
                       {
                         id: "add-rss-subscription",
                         text: "Add RSS subscription",
-                        href: `/rag/workspaces/add-data?tab=rssfeed&workspaceId=${workspaceId}`,
+                        href: `/rag/workspaces/add-data?tab=rssfeed&workspaceId=${workspace?.id}`,
                       },
                     ]}
                   >
@@ -135,7 +139,12 @@ export default function WorkspacePane() {
               {loading ? (
                 <StatusIndicator type="loading">Loading...</StatusIndicator>
               ) : (
-                workspace?.name
+                <>
+                    <SpaceBetween direction={"horizontal"} size={"s"}>
+                        <span>{workspace?.name}</span>
+                        {workspace?.is_writable == false ? <Badge color="red">ReadOnly</Badge> : ''}
+                    </SpaceBetween>
+                </>
               )}
             </Header>
           }
@@ -172,7 +181,7 @@ export default function WorkspacePane() {
                     id: "file",
                     content: (
                       <DocumentsTab
-                        workspaceId={workspaceId}
+                        workspace={workspace}
                         documentType="file"
                       />
                     ),
@@ -182,7 +191,7 @@ export default function WorkspacePane() {
                     id: "text",
                     content: (
                       <DocumentsTab
-                        workspaceId={workspaceId}
+                        workspace={workspace}
                         documentType="text"
                       />
                     ),
@@ -193,7 +202,7 @@ export default function WorkspacePane() {
                     disabled: disabledTabs.includes("qna"),
                     content: (
                       <DocumentsTab
-                        workspaceId={workspaceId}
+                        workspace={workspace}
                         documentType="qna"
                       />
                     ),
@@ -204,7 +213,7 @@ export default function WorkspacePane() {
                     disabled: disabledTabs.includes("website"),
                     content: (
                       <DocumentsTab
-                        workspaceId={workspaceId}
+                        workspace={workspace}
                         documentType="website"
                       />
                     ),
@@ -215,7 +224,7 @@ export default function WorkspacePane() {
                     disabled: disabledTabs.includes("rssfeed"),
                     content: (
                       <DocumentsTab
-                        workspaceId={workspaceId}
+                        workspace={workspace}
                         documentType="rssfeed"
                       />
                     ),

--- a/lib/user-interface/react-app/src/pages/rag/workspaces/column-definitions.tsx
+++ b/lib/user-interface/react-app/src/pages/rag/workspaces/column-definitions.tsx
@@ -1,4 +1,6 @@
 import { StatusIndicator, TableProps } from "@cloudscape-design/components";
+import Badge from "@cloudscape-design/components/badge";
+import SpaceBetween from "@cloudscape-design/components/space-between";
 import {
   PropertyFilterProperty,
   PropertyFilterOperator,
@@ -15,7 +17,12 @@ export const WorkspacesColumnDefinitions: TableProps.ColumnDefinition<Workspace>
       header: "Name",
       sortingField: "name",
       cell: (item: Workspace) => (
-        <RouterLink href={`/rag/workspaces/${item.id}`}>{item.name}</RouterLink>
+          <>
+            <SpaceBetween direction={"horizontal"} size={"xs"}>
+            <RouterLink href={`/rag/workspaces/${item.id}`}>{item.name}</RouterLink>
+            {item.isPublic == true ? <Badge color="red" >Public</Badge> : <Badge color="green" >Private</Badge>}
+            </SpaceBetween>
+          </>
       ),
       isRowHeader: true,
     },


### PR DESCRIPTION
Issue: https://github.com/aws-samples/aws-genai-llm-chatbot/issues/227

Implement private workspace, every user create a workspace now is only private and not shareable with other user.
This feature implement a new DynamoBD table handle policies on top of Workspace Dynamodb table.
This implementation could facilitate sharing workspaces between users with writeable / readable policy option through sharing process like Google Drive

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.