### PR TITLE
fix: Added None value for pydantic validation

### DIFF
--- a/lib/chatbot-api/functions/api-handler/routes/documents.py
+++ b/lib/chatbot-api/functions/api-handler/routes/documents.py
@@ -39,10 +39,10 @@ class WebsiteDocumentRequest(BaseModel):
 
 class RssFeedDocumentRequest(BaseModel):
     workspaceId: str
-    documentId: Optional[str]
-    address: Optional[str]
+    documentId: Optional[str] = None
+    address: Optional[str] = None
     limit: int
-    title: Optional[str]
+    title: Optional[str] = None
     followLinks: bool
 
 
@@ -55,7 +55,7 @@ class RssFeedCrawlerUpdateRequest(BaseModel):
 class ListDocumentsRequest(BaseModel):
     workspaceId: str
     documentType: str
-    lastDocumentId: Optional[str]
+    lastDocumentId: Optional[str] = None
 
 
 class GetDocumentRequest(BaseModel):
@@ -66,7 +66,7 @@ class GetDocumentRequest(BaseModel):
 class GetRssPostsRequest(BaseModel):
     workspaceId: str
     documentId: str
-    lastDocumentId: Optional[str]
+    lastDocumentId: Optional[str] = None
 
 
 class DocumentSubscriptionStatusRequest(BaseModel):


### PR DESCRIPTION
*Issue #, if available:*

UI not able to list Document in workspace for example, with Console log : 
"Field required [type=missing, "    for ListDocumentsRequest

Is related to pydantic parser validation from lambda powertools

https://docs.powertools.aws.dev/lambda/python/latest/utilities/parser/

*Description of changes:*

Optionnal Type is not sufficient, we need to initialize Optional fields to None

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
