### PR TITLE
Dealing with existant VPC for IdeficsInterface deployment

### DIFF
--- a/bin/config.ts
+++ b/bin/config.ts
@@ -11,6 +11,7 @@ export function getConfig(): SystemConfig {
     /* vpc: {
        vpcId: "vpc-00000000000000000",
        createVpcEndpoints: true,
+       vpcDefaultSecurityGroup: "sg-00000000000"
     },*/
     privateWebsite: false,
     certificate : "",

--- a/lib/model-interfaces/idefics/index.ts
+++ b/lib/model-interfaces/idefics/index.ts
@@ -38,10 +38,13 @@ export class IdeficsInterface extends Construct {
     // Create a private API to serve images and other files from S3
     // in order to avoid using signed URLs and run out of input tokens
     // with the idefics model
+    const defaultSecurityGroup = (props.config.vpc?.vpcId && props.config.vpc.vpcDefaultSecurityGroup) ?
+        props.config.vpc.vpcDefaultSecurityGroup : props.shared.vpc.vpcDefaultSecurityGroup
+
     const vpcDefaultSecurityGroup = ec2.SecurityGroup.fromSecurityGroupId(
-      this,
-      "VPCDefaultSecurityGroup",
-      props.shared.vpc.vpcDefaultSecurityGroup
+        this,
+        'VPCDefaultSecurityGroup',
+        defaultSecurityGroup
     );
 
     const vpcEndpoint = props.shared.vpc.addInterfaceEndpoint(

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -74,6 +74,7 @@ export interface SystemConfig {
   vpc?: {
     vpcId?: string;
     createVpcEndpoints?: boolean;
+    vpcDefaultSecurityGroup?: string;
   };
   certificate?: string;
   domain?: string;


### PR DESCRIPTION
Hi,

since release version 4.0.3 it seems there is condition disappeared for Idefics Interface activation or not.

You can compare this latest version with previous one like v4.0.3 at the same line :

[aws-genai-llm-chatbot/lib/aws-genai-llm-chatbot-stack.ts](https://github.com/aws-samples/aws-genai-llm-chatbot/blob/3c710bf28bd74eb3b576b863a4b678ed8ef06e0b/lib/aws-genai-llm-chatbot-stack.ts#L110)

Line 110 in [3c710bf](https://github.com/aws-samples/aws-genai-llm-chatbot/commit/3c710bf28bd74eb3b576b863a4b678ed8ef06e0b)

  
is it normal or a mistake ? In my case I cannot not deploy anymore due this new resource not available before and it need a default security group ID for private VPC endpoint.
This happened when VPC already exist, it seems the method "ec2.Vpc.fromLookup" does not detect a default security group.

Here the impact :

https://github.com/aws-samples/aws-genai-llm-chatbot/blob/main/lib/model-interfaces/idefics/index.ts#L41

This property "props.shared.vpc.vpcDefaultSecurityGroup" should contains a default security group ID.
For an existing VPC this value seems to be blank.

This condition impact also ResourcePath for NagSuppressions.

Best regards,