### PR TITLE
fix: lookup default sg when using existing vpc

### DIFF
--- a/lib/model-interfaces/idefics/index.ts
+++ b/lib/model-interfaces/idefics/index.ts
@@ -39,13 +39,13 @@ export class IdeficsInterface extends Construct {
     // in order to avoid using signed URLs and run out of input tokens
     // with the idefics model
     const defaultSecurityGroup = (props.config.vpc?.vpcId && props.config.vpc.vpcDefaultSecurityGroup) ?
-        props.config.vpc.vpcDefaultSecurityGroup : props.shared.vpc.vpcDefaultSecurityGroup
+        props.config.vpc.vpcDefaultSecurityGroup : props.shared.vpc.vpcDefaultSecurityGroup;
 
-    const vpcDefaultSecurityGroup = ec2.SecurityGroup.fromSecurityGroupId(
+    const vpcDefaultSecurityGroup = defaultSecurityGroup ? ec2.SecurityGroup.fromSecurityGroupId(
         this,
         'VPCDefaultSecurityGroup',
         defaultSecurityGroup
-    );
+    ) : ec2.SecurityGroup.fromLookupByName(this, 'VPCDefaultSecurityGroup', 'default', props.shared.vpc);
 
     const vpcEndpoint = props.shared.vpc.addInterfaceEndpoint(
       "PrivateApiEndpoint",


### PR DESCRIPTION
*Issue #, if available:*

closes #493 

*Description of changes:*

The VPC lookup does not lookup the default security group. So using the `default` name searches the security group.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
