### PR TITLE
Adding Bedrock Guardrails support

### DIFF
--- a/cli/magic-config.ts
+++ b/cli/magic-config.ts
@@ -13,31 +13,31 @@ import {
 } from "../lib/shared/types";
 import { LIB_VERSION } from "./version.js";
 import * as fs from "fs";
-import { AWSCronValidator } from "./aws-cron-validator"
-import { tz } from 'moment-timezone';
-import { getData } from 'country-list';
-import { randomBytes } from 'crypto';
-import { StringUtils } from 'turbocommons-ts';
+import { AWSCronValidator } from "./aws-cron-validator";
+import { tz } from "moment-timezone";
+import { getData } from "country-list";
+import { randomBytes } from "crypto";
+import { StringUtils } from "turbocommons-ts";
 
 function getTimeZonesWithCurrentTime(): { message: string; name: string }[] {
-    const timeZones = tz.names(); // Get a list of all timezones
-    const timeZoneData = timeZones.map(zone => {
-        // Get current time in each timezone
-        const currentTime = tz(zone).format('YYYY-MM-DD HH:mm');
-        return { message: `${zone}: ${currentTime}`, name: zone };
-    });
-    return timeZoneData;
+  const timeZones = tz.names(); // Get a list of all timezones
+  const timeZoneData = timeZones.map((zone) => {
+    // Get current time in each timezone
+    const currentTime = tz(zone).format("YYYY-MM-DD HH:mm");
+    return { message: `${zone}: ${currentTime}`, name: zone };
+  });
+  return timeZoneData;
 }
 
 function getCountryCodesAndNames(): { message: string; name: string }[] {
-    // Use country-list to get an array of countries with their codes and names
-    const countries = getData();
+  // Use country-list to get an array of countries with their codes and names
+  const countries = getData();
 
-    // Map the country data to match the desired output structure
-    const countryInfo = countries.map(({ code, name }) => {
-        return { message: `${name} (${code})`, name: code };
-    });
-    return countryInfo;
+  // Map the country data to match the desired output structure
+  const countryInfo = countries.map(({ code, name }) => {
+    return { message: `${name} (${code})`, name: code };
+  });
+  return countryInfo;
 }
 
 function isValidDate(dateString: string): boolean {
@@ -55,10 +55,14 @@ function isValidDate(dateString: string): boolean {
 
   // Check the date validity
   const date = new Date(year, month, day);
-  if (date.getFullYear() !== year || date.getMonth() !== month || date.getDate() !== day) {
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month ||
+    date.getDate() !== day
+  ) {
     return false;
   }
-  
+
   // Check if the date is in the future compared to the current date at 00:00:00
   const today = new Date();
   today.setHours(0, 0, 0, 0);
@@ -74,9 +78,13 @@ const cfCountries = getCountryCodesAndNames();
 
 const iamRoleRegExp = RegExp(/arn:aws:iam::\d+:role\/[\w-_]+/);
 const acmCertRegExp = RegExp(/arn:aws:acm:[\w-_]+:\d+:certificate\/[\w-_]+/);
-const cfAcmCertRegExp = RegExp(/arn:aws:acm:us-east-1:\d+:certificate\/[\w-_]+/);
+const cfAcmCertRegExp = RegExp(
+  /arn:aws:acm:us-east-1:\d+:certificate\/[\w-_]+/
+);
 const kendraIdRegExp = RegExp(/^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/);
-const secretManagerArnRegExp = RegExp(/arn:aws:secretsmanager:[\w-_]+:\d+:secret:[\w-_]+/);
+const secretManagerArnRegExp = RegExp(
+  /arn:aws:secretsmanager:[\w-_]+:\d+:secret:[\w-_]+/
+);
 
 const embeddingModels = [
   {
@@ -136,39 +144,34 @@ const embeddingModels = [
       );
       options.prefix = config.prefix;
       options.vpcId = config.vpc?.vpcId;
-      options.createVpcEndpoints = config.vpc?.createVpcEndpoints;
-      options.privateWebsite = config.privateWebsite;
-      options.certificate = config.certificate;
-      options.domain = config.domain;
-      options.cognitoFederationEnabled = config.cognitoFederation?.enabled;
-      options.cognitoCustomProviderName = config.cognitoFederation?.customProviderName;
-      options.cognitoCustomProviderType = config.cognitoFederation?.customProviderType;
-      options.cognitoCustomProviderSAMLMetadata = config.cognitoFederation?.customSAML?.metadataDocumentUrl;
-      options.cognitoCustomProviderOIDCClient = config.cognitoFederation?.customOIDC?.OIDCClient;
-      options.cognitoCustomProviderOIDCSecret = config.cognitoFederation?.customOIDC?.OIDCSecret;
-      options.cognitoCustomProviderOIDCIssuerURL = config.cognitoFederation?.customOIDC?.OIDCIssuerURL;
-      options.cognitoAutoRedirect = config.cognitoFederation?.autoRedirect;
-      options.cognitoDomain = config.cognitoFederation?.cognitoDomain;
-      options.cfGeoRestrictEnable = config.cfGeoRestrictEnable;
-      options.cfGeoRestrictList = config.cfGeoRestrictList;
       options.bedrockEnable = config.bedrock?.enabled;
       options.bedrockRegion = config.bedrock?.region;
       options.bedrockRoleArn = config.bedrock?.roleArn;
+      options.guardrailsEnable = config.bedrock?.guardrails?.enabled;
+      options.guardrails = config.bedrock?.guardrails;
       options.sagemakerModels = config.llms?.sagemaker ?? [];
       options.enableSagemakerModels = config.llms?.sagemaker
         ? config.llms?.sagemaker.length > 0
         : false;
       options.huggingfaceApiSecretArn = config.llms?.huggingfaceApiSecretArn;
-      options.enableSagemakerModelsSchedule = config.llms?.sagemakerSchedule?.enabled;
+      options.enableSagemakerModelsSchedule =
+        config.llms?.sagemakerSchedule?.enabled;
       options.timezonePicker = config.llms?.sagemakerSchedule?.timezonePicker;
-      options.enableCronFormat = config.llms?.sagemakerSchedule?.enableCronFormat;
-      options.cronSagemakerModelsScheduleStart = config.llms?.sagemakerSchedule?.sagemakerCronStartSchedule;
-      options.cronSagemakerModelsScheduleStop = config.llms?.sagemakerSchedule?.sagemakerCronStopSchedule;
+      options.enableCronFormat =
+        config.llms?.sagemakerSchedule?.enableCronFormat;
+      options.cronSagemakerModelsScheduleStart =
+        config.llms?.sagemakerSchedule?.sagemakerCronStartSchedule;
+      options.cronSagemakerModelsScheduleStop =
+        config.llms?.sagemakerSchedule?.sagemakerCronStopSchedule;
       options.daysForSchedule = config.llms?.sagemakerSchedule?.daysForSchedule;
-      options.scheduleStartTime = config.llms?.sagemakerSchedule?.scheduleStartTime;
-      options.scheduleStopTime = config.llms?.sagemakerSchedule?.scheduleStopTime;
-      options.enableScheduleEndDate = config.llms?.sagemakerSchedule?.enableScheduleEndDate;
-      options.startScheduleEndDate = config.llms?.sagemakerSchedule?.startScheduleEndDate;
+      options.scheduleStartTime =
+        config.llms?.sagemakerSchedule?.scheduleStartTime;
+      options.scheduleStopTime =
+        config.llms?.sagemakerSchedule?.scheduleStopTime;
+      options.enableScheduleEndDate =
+        config.llms?.sagemakerSchedule?.enableScheduleEndDate;
+      options.startScheduleEndDate =
+        config.llms?.sagemakerSchedule?.startScheduleEndDate;
       options.enableRag = config.rag.enabled;
       options.ragsToEnable = Object.keys(config.rag.engines ?? {}).filter(
         (v: string) => (config.rag.engines as any)[v].enabled
@@ -185,6 +188,30 @@ const embeddingModels = [
       )[0].name;
       options.kendraExternal = config.rag.engines.kendra.external;
       options.kendraEnterprise = config.rag.engines.kendra.enterprise;
+
+      // Advanced settings
+
+      options.createVpcEndpoints = config.vpc?.createVpcEndpoints;
+      options.privateWebsite = config.privateWebsite;
+      options.certificate = config.certificate;
+      options.domain = config.domain;
+      options.cognitoFederationEnabled = config.cognitoFederation?.enabled;
+      options.cognitoCustomProviderName =
+        config.cognitoFederation?.customProviderName;
+      options.cognitoCustomProviderType =
+        config.cognitoFederation?.customProviderType;
+      options.cognitoCustomProviderSAMLMetadata =
+        config.cognitoFederation?.customSAML?.metadataDocumentUrl;
+      options.cognitoCustomProviderOIDCClient =
+        config.cognitoFederation?.customOIDC?.OIDCClient;
+      options.cognitoCustomProviderOIDCSecret =
+        config.cognitoFederation?.customOIDC?.OIDCSecret;
+      options.cognitoCustomProviderOIDCIssuerURL =
+        config.cognitoFederation?.customOIDC?.OIDCIssuerURL;
+      options.cognitoAutoRedirect = config.cognitoFederation?.autoRedirect;
+      options.cognitoDomain = config.cognitoFederation?.cognitoDomain;
+      options.cfGeoRestrictEnable = config.cfGeoRestrictEnable;
+      options.cfGeoRestrictList = config.cfGeoRestrictList;
     }
     try {
       await processCreateOptions(options);
@@ -221,7 +248,8 @@ async function processCreateOptions(options: any): Promise<void> {
     {
       type: "confirm",
       name: "existingVpc",
-      message: "Do you want to use existing vpc? (selecting false will create a new vpc)",
+      message:
+        "Do you want to use existing vpc? (selecting false will create a new vpc)",
       initial: options.vpcId ? true : false,
     },
     {
@@ -230,230 +258,14 @@ async function processCreateOptions(options: any): Promise<void> {
       message: "Specify existing VpcId (vpc-xxxxxxxxxxxxxxxxx)",
       initial: options.vpcId,
       validate(vpcId: string) {
-        return ((this as any).skipped || RegExp(/^vpc-[0-9a-f]{8,17}$/i).test(vpcId)) ?
-          true : 'Enter a valid VpcId in vpc-xxxxxxxxxxx format'
+        return (this as any).skipped ||
+          RegExp(/^vpc-[0-9a-f]{8,17}$/i).test(vpcId)
+          ? true
+          : "Enter a valid VpcId in vpc-xxxxxxxxxxx format";
       },
       skip(): boolean {
         return !(this as any).state.answers.existingVpc;
       },
-    },
-    {
-      type: "confirm",
-      name: "createVpcEndpoints",
-      message: "Do you want create VPC Endpoints?",
-      initial: options.createVpcEndpoints || false,
-      skip(): boolean {
-        return !(this as any).state.answers.existingVpc;
-      },
-    },
-    {
-      type: "confirm",
-      name: "privateWebsite",
-      message:
-        "Do you want to deploy a private website? I.e only accessible in VPC",
-      initial: options.privateWebsite || false,
-    },
-    {
-      type: "confirm",
-      name: "customPublicDomain",
-      message:
-        "Do you want to provide a custom domain name and corresponding certificate arn for the public website ?",
-      initial: options.customPublicDomain || false,
-      skip(): boolean {
-        return (this as any).state.answers.privateWebsite ;
-      },
-    },
-    {
-      type: "input",
-      name: "certificate",
-      validate(v: string) {
-        if ((this as any).state.answers.privateWebsite)
-        {
-          const valid = acmCertRegExp.test(v);
-          return (this as any).skipped || valid
-            ? true
-            : "You need to enter an ACM certificate arn";
-        }
-        else
-        {
-          const valid = cfAcmCertRegExp.test(v);
-          return (this as any).skipped || valid
-            ? true
-            : "You need to enter an ACM certificate arn in us-east-1 for CF";
-        }
-      },
-      message(): string {
-        if ((this as any).state.answers.customPublicDomain) {
-          return "ACM certificate ARN with custom domain for public website. Note that the certificate must resides in us-east-1";
-        }
-        return "ACM certificate ARN";
-      },
-      initial: options.certificate,
-      skip(): boolean {
-        return !(this as any).state.answers.privateWebsite && !(this as any).state.answers.customPublicDomain;
-      },
-    },
-    {
-      type: "input",
-      name: "domain",
-      message(): string {
-        if ((this as any).state.answers.customPublicDomain) {
-          return "Custom Domain for public website i.e example.com";
-        }
-        return "Domain for private website i.e example.com";
-      },
-      validate(v: any) {
-        return (this as any).skipped || v.length > 0
-          ? true
-          : "You need to enter a domain name";
-      },
-      initial: options.domain,
-      skip(): boolean {
-        return !(this as any).state.answers.privateWebsite && !(this as any).state.answers.customPublicDomain;
-      },
-    },
-    {
-      type: "confirm",
-      name: "cognitoFederationEnabled",
-      message:
-        "Do you want to enable Federated (SSO) login with Cognito?",
-      initial: options.cognitoFederationEnabled || false,
-    },
-    {
-      type: "input",
-      name: "cognitoCustomProviderName",
-      message:
-        "Please enter the name of the SAML/OIDC Federated identity provider that is or will be setup in Cognito",
-      skip(): boolean {
-        return !(this as any).state.answers.cognitoFederationEnabled;
-      },
-      initial: options.cognitoCustomProviderName || "",
-    },
-    {
-      type: "select",
-      name: "cognitoCustomProviderType",
-      choices: [
-        { message: "Custom Cognito SAML", name: "SAML" },
-        { message: "Custom Cognito OIDC", name: "OIDC" },
-        { message: "Setup in Cognito Later", name: "later" },
-      ],
-      message:
-        "Do you want to setup a SAML or OIDC provider? or choose to do this later after install",
-      skip(): boolean {
-        (this as any).state._choices = (this as any).state.choices;
-        return !(this as any).state.answers.cognitoFederationEnabled;
-      },
-      initial: options.cognitoCustomProviderType || "",
-    },
-    {
-      type: "input",
-      name: "cognitoCustomProviderSAMLMetadata",
-      message:
-        "Provide a URL to a SAML metadata document. This document is issued by your SAML provider.",
-      validate(v: string) {
-        return ((this as any).skipped || StringUtils.isUrl(v)) ?
-          true : 'That does not look like a valid URL'
-      },
-      skip(): boolean {
-        if (!(this as any).state.answers.cognitoFederationEnabled){
-          return true;
-        }
-        return !(this as any).state.answers.cognitoCustomProviderType.includes("SAML");
-      },
-      initial: options.cognitoCustomProviderSAMLMetadata || "",
-    },
-    {
-      type: "input",
-      name: "cognitoCustomProviderOIDCClient",
-      message:
-        "Enter the client ID provided by OpenID Connect identity provider.",
-      validate(v: string) {
-        if ((this as any).skipped) {
-          return true
-        }
-        // Regular expression to match HH:MM format
-        const regex = /^[a-zA-Z0-9-_]{1,255}$/;
-        return regex.test(v) || 'Must only contain Alpha Numeric characters, "-" or "_" and be a maximum of 255 in length.';
-      },
-      skip(): boolean {
-        if (!(this as any).state.answers.cognitoFederationEnabled){
-          return true;
-        }
-        return !(this as any).state.answers.cognitoCustomProviderType.includes("OIDC");
-      },
-      initial: options.cognitoCustomProviderOIDCClient || "",
-    },
-    {
-      type: "input",
-      name: "cognitoCustomProviderOIDCSecret",
-      validate(v: string) {
-        const valid = secretManagerArnRegExp.test(v);
-        return (this as any).skipped || valid
-          ? true
-          : "You need to enter an Secret Manager Secret arn";
-      },
-      message:
-        "Enter the secret manager ARN containing the OIDC client secret to use (see docs for info)",
-      skip(): boolean {
-        if (!(this as any).state.answers.cognitoFederationEnabled){
-          return true;
-        }
-        return !(this as any).state.answers.cognitoCustomProviderType.includes("OIDC");
-      },
-      initial: options.cognitoCustomProviderOIDCSecret || "",
-    },
-    {
-      type: "input",
-      name: "cognitoCustomProviderOIDCIssuerURL",
-      message:
-        "Enter the issuer URL you received from the OIDC provider.",
-      validate(v: string) {
-        return ((this as any).skipped || StringUtils.isUrl(v)) ?
-          true : 'That does not look like a valid URL'
-      },
-      skip(): boolean {
-        if (!(this as any).state.answers.cognitoFederationEnabled){
-          return true;
-        }
-        return !(this as any).state.answers.cognitoCustomProviderType.includes("OIDC");
-      },
-      initial: options.cognitoCustomProviderOIDCIssuerURL || "",
-    },
-    {
-      type: "confirm",
-      name: "cognitoAutoRedirect",
-      message:
-        "Would you like to automatically redirect users to this identity provider?",
-      skip(): boolean {
-        return !(this as any).state.answers.cognitoFederationEnabled;
-      },
-      initial: options.cognitoAutoRedirect || false,
-    },
-    {
-      type: "confirm",
-      name: "cfGeoRestrictEnable",
-      message: "Do want to restrict access to the website (CF Distribution) to only a country or countries?",
-      initial: options.cfGeoRestrictEnable || false,
-      skip(): boolean {
-        return (this as any).state.answers.privateWebsite;
-      },
-    },
-    {
-      type: "multiselect",
-      name: "cfGeoRestrictList",
-      hint: "SPACE to select, ENTER to confirm selection",
-      message: "Which countries do you wish to ALLOW access?",
-      choices: cfCountries,
-      validate(choices: any) {
-        return (this as any).skipped || choices.length > 0
-          ? true
-          : "You need to select at least one country";
-      },
-      skip(): boolean {
-        (this as any).state._choices = (this as any).state.choices;
-        return (!(this as any).state.answers.cfGeoRestrictEnable || (this as any).state.answers.privateWebsite);
-      },
-      initial: options.cfGeoRestrictList || [],
     },
     {
       type: "confirm",
@@ -480,7 +292,37 @@ async function processCreateOptions(options: any): Promise<void> {
         const valid = iamRoleRegExp.test(v);
         return v.length === 0 || valid;
       },
-      initial: options.bedrockRoleArn || "",
+      initial: options.bedrockRoleArn ?? "",
+      skip() {
+        return !(this as any).state.answers.bedrockEnable;
+      },
+    },
+    {
+      type: "confirm",
+      name: "guardrailsEnable",
+      message: "Do you want to enable Bedrock Guardrails",
+      initial: options.guardrailsEnable ?? false,
+    },
+    {
+      type: "input",
+      name: "guardrailsIdentifier",
+      message: "Bedrock Guardrail Identifier",
+      validate(v: string) {
+        return (this as any).skipped || (v && v.length === 12);
+      },
+      skip() {
+        return !(this as any).state.answers.guardrailsEnable;
+      },
+      initial: options.guardrails?.identifier ?? "",
+    },
+    {
+      type: "input",
+      name: "guardrailsVersion",
+      message: "Bedrock Guardrail Version",
+      skip() {
+        return !(this as any).state.answers.guardrailsEnable;
+      },
+      initial: options.guardrails?.version ?? "DRAFT",
     },
     {
       type: "confirm",
@@ -501,8 +343,6 @@ async function processCreateOptions(options: any): Promise<void> {
             .includes(m)
         ) || [],
       validate(choices: any) {
-        //Trap for new players, validate always runs even if skipped is true
-        // So need to handle validate bail out if skipped is true
         return (this as any).skipped || choices.length > 0
           ? true
           : "You need to select at least one model";
@@ -521,7 +361,7 @@ async function processCreateOptions(options: any): Promise<void> {
         const valid = secretManagerArnRegExp.test(v);
         return v.length === 0 || valid
           ? true
-          : "If you are supplying a HF API key it needs to be a reference to a secrets manager secret ARN"
+          : "If you are supplying a HF API key it needs to be a reference to a secrets manager secret ARN";
       },
       initial: options.huggingfaceApiSecretArn || "",
       skip(): boolean {
@@ -531,9 +371,14 @@ async function processCreateOptions(options: any): Promise<void> {
     {
       type: "confirm",
       name: "enableSagemakerModelsSchedule",
-      message: "Do you want to enable a start/stop schedule for sagemaker models?",
+      message:
+        "Do you want to enable a start/stop schedule for sagemaker models?",
       initial(): boolean {
-        return (options.enableSagemakerModelsSchedule && (this as any).state.answers.enableSagemakerModels) || false;
+        return (
+          (options.enableSagemakerModelsSchedule &&
+            (this as any).state.answers.enableSagemakerModels) ||
+          false
+        );
       },
       skip(): boolean {
         return !(this as any).state.answers.enableSagemakerModels;
@@ -573,23 +418,23 @@ async function processCreateOptions(options: any): Promise<void> {
       type: "input",
       name: "sagemakerCronStartSchedule",
       hint: "This cron format is using AWS eventbridge cron syntax see docs for more information",
-      message: "Start schedule for Sagmaker models expressed in UTC AWS cron format",
+      message:
+        "Start schedule for Sagmaker models expressed in UTC AWS cron format",
       skip(): boolean {
         return !(this as any).state.answers.enableCronFormat.includes("cron");
       },
       validate(v: string) {
         if ((this as any).skipped) {
-          return true
+          return true;
         }
         try {
-          AWSCronValidator.validate(v)
-          return true
-        }
-        catch (error) {
-          if (error instanceof Error){
-            return error.message
+          AWSCronValidator.validate(v);
+          return true;
+        } catch (error) {
+          if (error instanceof Error) {
+            return error.message;
           }
-          return false
+          return false;
         }
       },
       initial: options.cronSagemakerModelsScheduleStart,
@@ -604,17 +449,16 @@ async function processCreateOptions(options: any): Promise<void> {
       },
       validate(v: string) {
         if ((this as any).skipped) {
-          return true
+          return true;
         }
         try {
-          AWSCronValidator.validate(v)
-          return true
-        }
-        catch (error) {
-          if (error instanceof Error){
-            return error.message
+          AWSCronValidator.validate(v);
+          return true;
+        } catch (error) {
+          if (error instanceof Error) {
+            return error.message;
           }
-          return false
+          return false;
         }
       },
       initial: options.cronSagemakerModelsScheduleStop,
@@ -640,7 +484,7 @@ async function processCreateOptions(options: any): Promise<void> {
       },
       skip(): boolean {
         (this as any).state._choices = (this as any).state.choices;
-        if (!(this as any).state.answers.enableSagemakerModelsSchedule){
+        if (!(this as any).state.answers.enableSagemakerModelsSchedule) {
           return true;
         }
         return !(this as any).state.answers.enableCronFormat.includes("simple");
@@ -650,17 +494,18 @@ async function processCreateOptions(options: any): Promise<void> {
     {
       type: "input",
       name: "scheduleStartTime",
-      message: "What time of day do you wish to run the start schedule? enter in HH:MM format",
+      message:
+        "What time of day do you wish to run the start schedule? enter in HH:MM format",
       validate(v: string) {
         if ((this as any).skipped) {
-          return true
+          return true;
         }
         // Regular expression to match HH:MM format
         const regex = /^([0-1]?[0-9]|2[0-3]):([0-5]?[0-9])$/;
-        return regex.test(v) || 'Time must be in HH:MM format!';
+        return regex.test(v) || "Time must be in HH:MM format!";
       },
       skip(): boolean {
-        if (!(this as any).state.answers.enableSagemakerModelsSchedule){
+        if (!(this as any).state.answers.enableSagemakerModelsSchedule) {
           return true;
         }
         return !(this as any).state.answers.enableCronFormat.includes("simple");
@@ -670,17 +515,18 @@ async function processCreateOptions(options: any): Promise<void> {
     {
       type: "input",
       name: "scheduleStopTime",
-      message: "What time of day do you wish to run the stop schedule? enter in HH:MM format",
+      message:
+        "What time of day do you wish to run the stop schedule? enter in HH:MM format",
       validate(v: string) {
         if ((this as any).skipped) {
-          return true
+          return true;
         }
         // Regular expression to match HH:MM format
         const regex = /^([0-1]?[0-9]|2[0-3]):([0-5]?[0-9])$/;
-        return regex.test(v) || 'Time must be in HH:MM format!';
+        return regex.test(v) || "Time must be in HH:MM format!";
       },
       skip(): boolean {
-        if (!(this as any).state.answers.enableSagemakerModelsSchedule){
+        if (!(this as any).state.answers.enableSagemakerModelsSchedule) {
           return true;
         }
         return !(this as any).state.answers.enableCronFormat.includes("simple");
@@ -690,7 +536,8 @@ async function processCreateOptions(options: any): Promise<void> {
     {
       type: "confirm",
       name: "enableScheduleEndDate",
-      message: "Would you like to set an end data for the start schedule? (after this date the models would no longer start)",
+      message:
+        "Would you like to set an end data for the start schedule? (after this date the models would no longer start)",
       initial: options.enableScheduleEndDate || false,
       skip(): boolean {
         return !(this as any).state.answers.enableSagemakerModelsSchedule;
@@ -703,9 +550,12 @@ async function processCreateOptions(options: any): Promise<void> {
       hint: "YYYY-MM-DD",
       validate(v: string) {
         if ((this as any).skipped) {
-          return true
+          return true;
         }
-        return isValidDate(v) || 'The date must be in format YYYY/MM/DD and be in the future';
+        return (
+          isValidDate(v) ||
+          "The date must be in format YYYY/MM/DD and be in the future"
+        );
       },
       skip(): boolean {
         return !(this as any).state.answers.enableScheduleEndDate;
@@ -758,10 +608,7 @@ async function processCreateOptions(options: any): Promise<void> {
           options.kendraExternal.length > 0) ||
         false,
       skip(): boolean {
-        if (!(this as any).state.answers.enableRag){
-          return true;
-        }
-        return !(this as any).state.answers.ragsToEnable.includes("kendra");
+        return !(this as any).state.answers.enableRag;
       },
     },
   ];
@@ -840,84 +687,353 @@ async function processCreateOptions(options: any): Promise<void> {
   }
   const modelsPrompts = [
     {
-      type: "select", 
+      type: "select",
       name: "defaultEmbedding",
       message: "Select a default embedding model",
-      choices: embeddingModels.map(m => ({name: m.name, value: m})),
+      choices: embeddingModels.map((m) => ({ name: m.name, value: m })),
       initial: options.defaultEmbedding,
       validate(value: string) {
         if ((this as any).state.answers.enableRag) {
-          return value ? true : 'Select a default embedding model'; 
+          return value ? true : "Select a default embedding model";
         }
-      
+
         return true;
       },
       skip() {
-        return !answers.enableRag || !(answers.ragsToEnable.includes("aurora") || answers.ragsToEnable.includes("opensearch"));
-      }
-    }
+        return (
+          !answers.enableRag ||
+          !(
+            answers.ragsToEnable.includes("aurora") ||
+            answers.ragsToEnable.includes("opensearch")
+          )
+        );
+      },
+    },
   ];
   const models: any = await enquirer.prompt(modelsPrompts);
 
+  const advancedSettingsPrompts = [
+    {
+      type: "confirm",
+      name: "createVpcEndpoints",
+      message: "Do you want create VPC Endpoints?",
+      initial: options.createVpcEndpoints || false,
+      skip(): boolean {
+        return !(this as any).state.answers.existingVpc;
+      },
+    },
+    {
+      type: "confirm",
+      name: "privateWebsite",
+      message:
+        "Do you want to deploy a private website? I.e only accessible in VPC",
+      initial: options.privateWebsite || false,
+    },
+    {
+      type: "confirm",
+      name: "customPublicDomain",
+      message:
+        "Do you want to provide a custom domain name and corresponding certificate arn for the public website ?",
+      initial: options.customPublicDomain || false,
+      skip(): boolean {
+        return (this as any).state.answers.privateWebsite;
+      },
+    },
+    {
+      type: "input",
+      name: "certificate",
+      validate(v: string) {
+        if ((this as any).state.answers.privateWebsite) {
+          const valid = acmCertRegExp.test(v);
+          return (this as any).skipped || valid
+            ? true
+            : "You need to enter an ACM certificate arn";
+        } else {
+          const valid = cfAcmCertRegExp.test(v);
+          return (this as any).skipped || valid
+            ? true
+            : "You need to enter an ACM certificate arn in us-east-1 for CF";
+        }
+      },
+      message(): string {
+        if ((this as any).state.answers.customPublicDomain) {
+          return "ACM certificate ARN with custom domain for public website. Note that the certificate must resides in us-east-1";
+        }
+        return "ACM certificate ARN";
+      },
+      initial: options.certificate,
+      skip(): boolean {
+        return (
+          !(this as any).state.answers.privateWebsite &&
+          !(this as any).state.answers.customPublicDomain
+        );
+      },
+    },
+    {
+      type: "input",
+      name: "domain",
+      message(): string {
+        if ((this as any).state.answers.customPublicDomain) {
+          return "Custom Domain for public website i.e example.com";
+        }
+        return "Domain for private website i.e example.com";
+      },
+      validate(v: any) {
+        return (this as any).skipped || v.length > 0
+          ? true
+          : "You need to enter a domain name";
+      },
+      initial: options.domain,
+      skip(): boolean {
+        return (
+          !(this as any).state.answers.privateWebsite &&
+          !(this as any).state.answers.customPublicDomain
+        );
+      },
+    },
+    {
+      type: "confirm",
+      name: "cognitoFederationEnabled",
+      message: "Do you want to enable Federated (SSO) login with Cognito?",
+      initial: options.cognitoFederationEnabled || false,
+    },
+    {
+      type: "input",
+      name: "cognitoCustomProviderName",
+      message:
+        "Please enter the name of the SAML/OIDC Federated identity provider that is or will be setup in Cognito",
+      skip(): boolean {
+        return !(this as any).state.answers.cognitoFederationEnabled;
+      },
+      initial: options.cognitoCustomProviderName || "",
+    },
+    {
+      type: "select",
+      name: "cognitoCustomProviderType",
+      choices: [
+        { message: "Custom Cognito SAML", name: "SAML" },
+        { message: "Custom Cognito OIDC", name: "OIDC" },
+        { message: "Setup in Cognito Later", name: "later" },
+      ],
+      message:
+        "Do you want to setup a SAML or OIDC provider? or choose to do this later after install",
+      skip(): boolean {
+        (this as any).state._choices = (this as any).state.choices;
+        return !(this as any).state.answers.cognitoFederationEnabled;
+      },
+      initial: options.cognitoCustomProviderType || "",
+    },
+    {
+      type: "input",
+      name: "cognitoCustomProviderSAMLMetadata",
+      message:
+        "Provide a URL to a SAML metadata document. This document is issued by your SAML provider.",
+      validate(v: string) {
+        return (this as any).skipped || StringUtils.isUrl(v)
+          ? true
+          : "That does not look like a valid URL";
+      },
+      skip(): boolean {
+        if (!(this as any).state.answers.cognitoFederationEnabled) {
+          return true;
+        }
+        return !(this as any).state.answers.cognitoCustomProviderType.includes(
+          "SAML"
+        );
+      },
+      initial: options.cognitoCustomProviderSAMLMetadata || "",
+    },
+    {
+      type: "input",
+      name: "cognitoCustomProviderOIDCClient",
+      message:
+        "Enter the client ID provided by OpenID Connect identity provider.",
+      validate(v: string) {
+        if ((this as any).skipped) {
+          return true;
+        }
+        // Regular expression to match HH:MM format
+        const regex = /^[a-zA-Z0-9-_]{1,255}$/;
+        return (
+          regex.test(v) ||
+          'Must only contain Alpha Numeric characters, "-" or "_" and be a maximum of 255 in length.'
+        );
+      },
+      skip(): boolean {
+        if (!(this as any).state.answers.cognitoFederationEnabled) {
+          return true;
+        }
+        return !(this as any).state.answers.cognitoCustomProviderType.includes(
+          "OIDC"
+        );
+      },
+      initial: options.cognitoCustomProviderOIDCClient || "",
+    },
+    {
+      type: "input",
+      name: "cognitoCustomProviderOIDCSecret",
+      validate(v: string) {
+        const valid = secretManagerArnRegExp.test(v);
+        return (this as any).skipped || valid
+          ? true
+          : "You need to enter an Secret Manager Secret arn";
+      },
+      message:
+        "Enter the secret manager ARN containing the OIDC client secret to use (see docs for info)",
+      skip(): boolean {
+        if (!(this as any).state.answers.cognitoFederationEnabled) {
+          return true;
+        }
+        return !(this as any).state.answers.cognitoCustomProviderType.includes(
+          "OIDC"
+        );
+      },
+      initial: options.cognitoCustomProviderOIDCSecret || "",
+    },
+    {
+      type: "input",
+      name: "cognitoCustomProviderOIDCIssuerURL",
+      message: "Enter the issuer URL you received from the OIDC provider.",
+      validate(v: string) {
+        return (this as any).skipped || StringUtils.isUrl(v)
+          ? true
+          : "That does not look like a valid URL";
+      },
+      skip(): boolean {
+        if (!(this as any).state.answers.cognitoFederationEnabled) {
+          return true;
+        }
+        return !(this as any).state.answers.cognitoCustomProviderType.includes(
+          "OIDC"
+        );
+      },
+      initial: options.cognitoCustomProviderOIDCIssuerURL || "",
+    },
+    {
+      type: "confirm",
+      name: "cognitoAutoRedirect",
+      message:
+        "Would you like to automatically redirect users to this identity provider?",
+      skip(): boolean {
+        return !(this as any).state.answers.cognitoFederationEnabled;
+      },
+      initial: options.cognitoAutoRedirect || false,
+    },
+    {
+      type: "confirm",
+      name: "cfGeoRestrictEnable",
+      message:
+        "Do want to restrict access to the website (CF Distribution) to only a country or countries?",
+      initial: options.cfGeoRestrictEnable || false,
+      skip(): boolean {
+        return (this as any).state.answers.privateWebsite;
+      },
+    },
+    {
+      type: "multiselect",
+      name: "cfGeoRestrictList",
+      hint: "SPACE to select, ENTER to confirm selection",
+      message: "Which countries do you wish to ALLOW access?",
+      choices: cfCountries,
+      validate(choices: any) {
+        return (this as any).skipped || choices.length > 0
+          ? true
+          : "You need to select at least one country";
+      },
+      skip(): boolean {
+        (this as any).state._choices = (this as any).state.choices;
+        return (
+          !(this as any).state.answers.cfGeoRestrictEnable ||
+          (this as any).state.answers.privateWebsite
+        );
+      },
+      initial: options.cfGeoRestrictList || [],
+    },
+  ];
+
+  const doAdvancedConfirm: any = await enquirer.prompt([
+    {
+      type: "confirm",
+      name: "doAdvancedSettings",
+      message: "Do you want to configure advanced settings?",
+      initial: false,
+    },
+  ]);
+  let advancedSettings: any = {};
+  if (doAdvancedConfirm.doAdvancedSettings) {
+    advancedSettings = await enquirer.prompt(advancedSettingsPrompts);
+  }
   // Convert simple time into cron format for schedule
-  if (answers.enableSagemakerModelsSchedule && answers.enableCronFormat == "simple")
-  {
+  if (
+    answers.enableSagemakerModelsSchedule &&
+    answers.enableCronFormat == "simple"
+  ) {
     const daysToRunSchedule = answers.daysForSchedule.join(",");
     const startMinutes = answers.scheduleStartTime.split(":")[1];
     const startHour = answers.scheduleStartTime.split(":")[0];
     answers.sagemakerCronStartSchedule = `${startMinutes} ${startHour} ? * ${daysToRunSchedule} *`;
-    AWSCronValidator.validate(answers.sagemakerCronStartSchedule)
+    AWSCronValidator.validate(answers.sagemakerCronStartSchedule);
 
-    
     const stopMinutes = answers.scheduleStopTime.split(":")[1];
     const stopHour = answers.scheduleStopTime.split(":")[0];
     answers.sagemakerCronStopSchedule = `${stopMinutes} ${stopHour} ? * ${daysToRunSchedule} *`;
-    AWSCronValidator.validate(answers.sagemakerCronStopSchedule)
+    AWSCronValidator.validate(answers.sagemakerCronStopSchedule);
   }
-  
-  const randomSuffix = randomBytes(8).toString('hex');
-  
+
+  const randomSuffix = randomBytes(8).toString("hex");
+
   // Create the config object
   const config = {
     prefix: answers.prefix,
     vpc: answers.existingVpc
       ? {
           vpcId: answers.vpcId.toLowerCase(),
-          createVpcEndpoints: answers.createVpcEndpoints,
-      }
-      : undefined,
-    privateWebsite: answers.privateWebsite,
-    certificate: answers.certificate,
-    domain: answers.domain,
-    cognitoFederation: answers.cognitoFederationEnabled
-      ? {
-          enabled: answers.cognitoFederationEnabled,
-          autoRedirect: answers.cognitoAutoRedirect,
-          customProviderName: answers.cognitoCustomProviderName,
-          customProviderType: answers.cognitoCustomProviderType,
-          customSAML: answers.cognitoCustomProviderType == "SAML"
-            ? {
-                metadataDocumentUrl: answers.cognitoCustomProviderSAMLMetadata
-            }
-            : undefined,
-          customOIDC: answers.cognitoCustomProviderType == "OIDC"
-            ? {
-                OIDCClient: answers.cognitoCustomProviderOIDCClient,
-                OIDCSecret: answers.cognitoCustomProviderOIDCSecret,
-                OIDCIssuerURL: answers.cognitoCustomProviderOIDCIssuerURL,
-            }
-            : undefined,
-          cognitoDomain: options.cognitoDomain ? options.cognitoDomain : `llm-cb-${randomSuffix}`,
+          createVpcEndpoints: advancedSettings.createVpcEndpoints,
         }
       : undefined,
-    cfGeoRestrictEnable: answers.cfGeoRestrictEnable,
-    cfGeoRestrictList: answers.cfGeoRestrictList,
+    privateWebsite: advancedSettings.privateWebsite,
+    certificate: advancedSettings.certificate,
+    domain: advancedSettings.domain,
+    cognitoFederation: advancedSettings.cognitoFederationEnabled
+      ? {
+          enabled: advancedSettings.cognitoFederationEnabled,
+          autoRedirect: advancedSettings.cognitoAutoRedirect,
+          customProviderName: advancedSettings.cognitoCustomProviderName,
+          customProviderType: advancedSettings.cognitoCustomProviderType,
+          customSAML:
+            advancedSettings.cognitoCustomProviderType == "SAML"
+              ? {
+                  metadataDocumentUrl:
+                    advancedSettings.cognitoCustomProviderSAMLMetadata,
+                }
+              : undefined,
+          customOIDC:
+            advancedSettings.cognitoCustomProviderType == "OIDC"
+              ? {
+                  OIDCClient: advancedSettings.cognitoCustomProviderOIDCClient,
+                  OIDCSecret: advancedSettings.cognitoCustomProviderOIDCSecret,
+                  OIDCIssuerURL:
+                    advancedSettings.cognitoCustomProviderOIDCIssuerURL,
+                }
+              : undefined,
+          cognitoDomain: advancedSettings.cognitoDomain
+            ? advancedSettings.cognitoDomain
+            : `llm-cb-${randomSuffix}`,
+        }
+      : undefined,
+    cfGeoRestrictEnable: advancedSettings.cfGeoRestrictEnable,
+    cfGeoRestrictList: advancedSettings.cfGeoRestrictList,
     bedrock: answers.bedrockEnable
       ? {
           enabled: answers.bedrockEnable,
           region: answers.bedrockRegion,
           roleArn:
             answers.bedrockRoleArn === "" ? undefined : answers.bedrockRoleArn,
+          guardrails: {
+            enabled: answers.guardrailsEnable,
+            identifier: answers.guardrailsIdentifier,
+            version: answers.guardrailsVersion,
+          },
         }
       : undefined,
     llms: {
@@ -990,7 +1106,8 @@ async function processCreateOptions(options: any): Promise<void> {
       {
         type: "confirm",
         name: "create",
-        message: "Do you want to create/update the configuration based on the above settings",
+        message:
+          "Do you want to create/update the configuration based on the above settings",
         initial: true,
       },
     ])) as any

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/ai21_j2.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/ai21_j2.py
@@ -1,5 +1,5 @@
 import genai_core.clients
-from langchain_community.llms import Bedrock
+from langchain_aws import BedrockLLM
 from langchain.prompts.prompt import PromptTemplate
 
 from ..base import ModelAdapter
@@ -23,7 +23,7 @@ class AI21J2Adapter(ModelAdapter):
         if "maxTokens" in model_kwargs:
             params["maxTokens"] = model_kwargs["maxTokens"]
 
-        return Bedrock(
+        return BedrockLLM(
             client=bedrock,
             model_id=self.model_id,
             model_kwargs=params,

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/ai21_j2.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/ai21_j2.py
@@ -3,6 +3,7 @@ from langchain_aws import BedrockLLM
 from langchain.prompts.prompt import PromptTemplate
 
 from ..base import ModelAdapter
+from .base import get_guardrails
 from genai_core.registry import registry
 
 
@@ -23,11 +24,16 @@ class AI21J2Adapter(ModelAdapter):
         if "maxTokens" in model_kwargs:
             params["maxTokens"] = model_kwargs["maxTokens"]
 
+        extra = {}
+        guardrails = get_guardrails()
+        if len(guardrails.keys()) > 0:
+            extra = {"guardrails": guardrails}
         return BedrockLLM(
             client=bedrock,
             model_id=self.model_id,
             model_kwargs=params,
             callbacks=[self.callback_handler],
+            **extra
         )
 
     def get_prompt(self):

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/base.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/base.py
@@ -1,4 +1,5 @@
 import json
+import os
 import warnings
 from abc import ABC
 from typing import Any, Dict, Iterator, List, Mapping, Optional
@@ -12,6 +13,18 @@ from langchain.utilities.anthropic import (
     get_num_tokens_anthropic,
     get_token_ids_anthropic,
 )
+
+
+def get_guardrails() -> dict:
+    if (
+        "BEDROCK_GUARDRAILS_ID" in os.environ
+        and "BEDROCK_GUARDRAILS_VERSION" in os.environ
+    ):
+        return {
+            "guardrailIdentifier": os.environ["BEDROCK_GUARDRAILS_ID"],
+            "guardrailVersion": os.environ["BEDROCK_GUARDRAILS_VERSION"],
+        }
+    return {}
 
 
 class LLMInputOutputAdapter:
@@ -191,9 +204,14 @@ class BedrockBase(BaseModel, ABC):
         body = json.dumps(input_body)
         accept = "application/json"
         contentType = "application/json"
+        guardrails = get_guardrails()
         try:
             response = self.client.invoke_model(
-                body=body, modelId=self.model_id, accept=accept, contentType=contentType
+                body=body,
+                modelId=self.model_id,
+                accept=accept,
+                contentType=contentType,
+                **guardrails,
             )
             text = LLMInputOutputAdapter.prepare_output(provider, response)
 
@@ -231,12 +249,14 @@ class BedrockBase(BaseModel, ABC):
         params = {**_model_kwargs, **kwargs}
         input_body = LLMInputOutputAdapter.prepare_input(provider, prompt, params)
         body = json.dumps(input_body)
+        guardrails = get_guardrails()
         try:
             response = self.client.invoke_model_with_response_stream(
                 body=body,
                 modelId=self.model_id,
                 accept="application/json",
                 contentType="application/json",
+                **guardrails,
             )
         except Exception as e:
             raise ValueError(f"Error raised by bedrock service: {e}")

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/base.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/base.py
@@ -16,13 +16,10 @@ from langchain.utilities.anthropic import (
 
 
 def get_guardrails() -> dict:
-    if (
-        "BEDROCK_GUARDRAILS_ID" in os.environ
-        and "BEDROCK_GUARDRAILS_VERSION" in os.environ
-    ):
+    if "BEDROCK_GUARDRAILS_ID" in os.environ:
         return {
             "guardrailIdentifier": os.environ["BEDROCK_GUARDRAILS_ID"],
-            "guardrailVersion": os.environ["BEDROCK_GUARDRAILS_VERSION"],
+            "guardrailVersion": os.environ.get("BEDROCK_GUARDRAILS_VERSION", "DRAFT"),
         }
     return {}
 

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/claude.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/claude.py
@@ -3,7 +3,7 @@ import genai_core.clients
 # from langchain_community.llms import Bedrock
 from langchain.prompts.prompt import PromptTemplate
 
-from .base import Bedrock
+from langchain_aws import BedrockLLM
 from ..base import ModelAdapter
 from genai_core.registry import registry
 
@@ -25,7 +25,7 @@ class BedrockClaudeAdapter(ModelAdapter):
             params["max_tokens"] = model_kwargs["maxTokens"]
 
         params["anthropic_version"] = "bedrock-2023-05-31"
-        return Bedrock(
+        return BedrockLLM(
             client=bedrock,
             model_id=self.model_id,
             model_kwargs=params,

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/claude.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/claude.py
@@ -2,8 +2,7 @@ import genai_core.clients
 
 # from langchain_community.llms import Bedrock
 from langchain.prompts.prompt import PromptTemplate
-
-from langchain_aws import BedrockLLM
+from .base import Bedrock
 from ..base import ModelAdapter
 from genai_core.registry import registry
 
@@ -25,7 +24,7 @@ class BedrockClaudeAdapter(ModelAdapter):
             params["max_tokens"] = model_kwargs["maxTokens"]
 
         params["anthropic_version"] = "bedrock-2023-05-31"
-        return BedrockLLM(
+        return Bedrock(
             client=bedrock,
             model_id=self.model_id,
             model_kwargs=params,

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/cohere.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/cohere.py
@@ -1,6 +1,6 @@
 import genai_core.clients
 
-from langchain_community.llms import Bedrock
+from langchain_aws import BedrockLLM
 from langchain.prompts.prompt import PromptTemplate
 
 from ..base import ModelAdapter
@@ -23,7 +23,7 @@ class BedrockCohereCommandAdapter(ModelAdapter):
             params["max_tokens"] = model_kwargs["maxTokens"]
         params["return_likelihoods"] = "GENERATION"
 
-        return Bedrock(
+        return BedrockLLM(
             client=bedrock,
             model_id=self.model_id,
             model_kwargs=params,
@@ -56,5 +56,5 @@ Assistant:"""
 
 # Register the adapter
 registry.register(
-    r"^bedrock\.cohere\.command-(text|light-text).*", BedrockCohereCommandAdapter
+    r"^bedrock\.cohere\.command-(text|light-text|r).*", BedrockCohereCommandAdapter
 )

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/cohere.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/cohere.py
@@ -4,7 +4,7 @@ from langchain_aws import BedrockLLM
 from langchain.prompts.prompt import PromptTemplate
 
 from ..base import ModelAdapter
-from .base import get_guardrails, Bedrock
+from .base import get_guardrails
 from genai_core.registry import registry
 
 

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/cohere.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/cohere.py
@@ -4,6 +4,7 @@ from langchain_aws import BedrockLLM
 from langchain.prompts.prompt import PromptTemplate
 
 from ..base import ModelAdapter
+from .base import get_guardrails
 from genai_core.registry import registry
 
 
@@ -23,12 +24,17 @@ class BedrockCohereCommandAdapter(ModelAdapter):
             params["max_tokens"] = model_kwargs["maxTokens"]
         params["return_likelihoods"] = "GENERATION"
 
+        extra = {}
+        guardrails = get_guardrails()
+        if len(guardrails.keys()) > 0:
+            extra = {"guardrails": guardrails}
         return BedrockLLM(
             client=bedrock,
             model_id=self.model_id,
             model_kwargs=params,
             streaming=model_kwargs.get("streaming", False),
             callbacks=[self.callback_handler],
+            **extra
         )
 
     def get_prompt(self):

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/cohere.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/cohere.py
@@ -4,7 +4,7 @@ from langchain_aws import BedrockLLM
 from langchain.prompts.prompt import PromptTemplate
 
 from ..base import ModelAdapter
-from .base import get_guardrails
+from .base import get_guardrails, Bedrock
 from genai_core.registry import registry
 
 
@@ -62,5 +62,5 @@ Assistant:"""
 
 # Register the adapter
 registry.register(
-    r"^bedrock\.cohere\.command-(text|light-text|r).*", BedrockCohereCommandAdapter
+    r"^bedrock\.cohere\.command-(text|light-text).*", BedrockCohereCommandAdapter
 )

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/llama2_chat.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/llama2_chat.py
@@ -3,9 +3,6 @@ import genai_core.clients
 # from langchain_community.llms import Bedrock (pending https://github.com/langchain-ai/langchain/issues/13316)
 from .base import Bedrock
 
-from langchain.prompts.prompt import PromptTemplate
-
-
 from ..shared.meta.llama2_chat import (
     Llama2ChatPromptTemplate,
     Llama2ChatQAPromptTemplate,
@@ -14,6 +11,7 @@ from ..shared.meta.llama2_chat import (
 from ..shared.meta.llama2_chat import Llama2ConversationBufferMemory
 
 from ..base import ModelAdapter
+from .base import get_guardrails
 from genai_core.registry import registry
 
 
@@ -42,12 +40,17 @@ class BedrockMetaLLama2ChatAdapter(ModelAdapter):
         if "maxTokens" in model_kwargs:
             params["max_gen_len"] = model_kwargs["maxTokens"]
 
+        extra = {}
+        guardrails = get_guardrails()
+        if len(guardrails.keys()) > 0:
+            extra = {"guardrails": guardrails}
         return Bedrock(
             client=bedrock,
             model_id=self.model_id,
             model_kwargs=params,
             streaming=model_kwargs.get("streaming", False),
             callbacks=[self.callback_handler],
+            **extra,
         )
 
     def get_prompt(self):

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/mistral.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/mistral.py
@@ -2,6 +2,7 @@ from .llama2_chat import BedrockMetaLLama2ChatAdapter
 from genai_core.registry import registry
 import genai_core
 from langchain_aws import BedrockLLM
+from .base import get_guardrails
 
 
 class BedrockMistralAdapter(BedrockMetaLLama2ChatAdapter):
@@ -16,6 +17,10 @@ class BedrockMistralAdapter(BedrockMetaLLama2ChatAdapter):
         if "maxTokens" in model_kwargs:
             params["max_tokens"] = model_kwargs["maxTokens"]
 
+        extra = {}
+        guardrails = get_guardrails()
+        if len(guardrails.keys()) > 0:
+            extra = {"guardrails": guardrails}
         return BedrockLLM(
             client=bedrock,
             model_id=self.model_id,

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/mistral.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/mistral.py
@@ -1,7 +1,7 @@
 from .llama2_chat import BedrockMetaLLama2ChatAdapter
 from genai_core.registry import registry
 import genai_core
-from .base import Bedrock
+from langchain_aws import BedrockLLM
 
 
 class BedrockMistralAdapter(BedrockMetaLLama2ChatAdapter):
@@ -16,7 +16,7 @@ class BedrockMistralAdapter(BedrockMetaLLama2ChatAdapter):
         if "maxTokens" in model_kwargs:
             params["max_tokens"] = model_kwargs["maxTokens"]
 
-        return Bedrock(
+        return BedrockLLM(
             client=bedrock,
             model_id=self.model_id,
             model_kwargs=params,

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/titan.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/titan.py
@@ -4,6 +4,7 @@ from langchain.prompts.prompt import PromptTemplate
 from langchain_aws import BedrockLLM
 
 from ..base import ModelAdapter
+from .base import get_guardrails
 from genai_core.registry import registry
 
 
@@ -23,6 +24,11 @@ class BedrockTitanAdapter(ModelAdapter):
             params["topP"] = model_kwargs["topP"]
         if "maxTokens" in model_kwargs:
             params["maxTokenCount"] = model_kwargs["maxTokens"]
+
+        extra = {}
+        guardrails = get_guardrails()
+        if len(guardrails.keys()) > 0:
+            extra = {"guardrails": guardrails}
 
         return BedrockLLM(
             client=bedrock,

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/titan.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/titan.py
@@ -1,7 +1,7 @@
 import genai_core.clients
 from langchain.prompts.prompt import PromptTemplate
 
-from langchain_community.llms import Bedrock
+from langchain_aws import BedrockLLM
 
 from ..base import ModelAdapter
 from genai_core.registry import registry
@@ -24,7 +24,7 @@ class BedrockTitanAdapter(ModelAdapter):
         if "maxTokens" in model_kwargs:
             params["maxTokenCount"] = model_kwargs["maxTokens"]
 
-        return Bedrock(
+        return BedrockLLM(
             client=bedrock,
             model_id=self.model_id,
             model_kwargs=params,

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/sagemaker/meta/llama2_chat.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/sagemaker/meta/llama2_chat.py
@@ -1,7 +1,7 @@
 import json
 import os
 
-from langchain.llms.sagemaker_endpoint import LLMContentHandler, SagemakerEndpoint
+from langchain_community.llms.sagemaker_endpoint import LLMContentHandler, SagemakerEndpoint
 
 from ...base import ModelAdapter
 from genai_core.registry import registry

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/sagemaker/mistralai/mistral_instruct.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/sagemaker/mistralai/mistral_instruct.py
@@ -1,7 +1,10 @@
 import json
 import os
 
-from langchain.llms.sagemaker_endpoint import LLMContentHandler, SagemakerEndpoint
+from langchain_community.llms.sagemaker_endpoint import (
+    LLMContentHandler,
+    SagemakerEndpoint,
+)
 from langchain.prompts.prompt import PromptTemplate
 
 from ...base import ModelAdapter

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/sagemaker/mistralai/mixtral_instruct.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/sagemaker/mistralai/mixtral_instruct.py
@@ -1,7 +1,10 @@
 import json
 import os
 
-from langchain.llms.sagemaker_endpoint import LLMContentHandler, SagemakerEndpoint
+from langchain_community.llms.sagemaker_endpoint import (
+    LLMContentHandler,
+    SagemakerEndpoint,
+)
 from langchain.prompts.prompt import PromptTemplate
 
 from ...base import ModelAdapter

--- a/lib/model-interfaces/langchain/index.ts
+++ b/lib/model-interfaces/langchain/index.ts
@@ -13,6 +13,7 @@ import { RagEngines } from "../../rag-engines";
 import { Shared } from "../../shared";
 import { SystemConfig } from "../../shared/types";
 import { NagSuppressions } from "cdk-nag";
+import { request } from "http";
 
 interface LangChainInterfaceProps {
   readonly shared: Shared;
@@ -93,6 +94,17 @@ export class LangChainInterface extends Construct {
           })
         );
       }
+    }
+
+    if (props.config.bedrock?.guardrails?.enabled) {
+      requestHandler.addEnvironment(
+        "BEDROCK_GUARDRAILS_ID",
+        props.config.bedrock.guardrails.identifier
+      );
+      requestHandler.addEnvironment(
+        "BEDROCK_GUARDRAILS_VERSION",
+        props.config.bedrock.guardrails.version
+      );
     }
 
     if (props.ragEngines?.auroraPgVector) {

--- a/lib/shared/layers/common/requirements.txt
+++ b/lib/shared/layers/common/requirements.txt
@@ -4,8 +4,9 @@ numpy==1.26.0
 cfnresponse==1.1.2
 aws_requests_auth==0.4.3
 requests-aws4auth==1.2.3
-langchain==0.1.17
-langchain-community==0.0.36
+langchain==0.2.3
+langchain-community==0.2.4
+langchain-aws==0.1.6
 opensearch-py==2.4.2
 psycopg2-binary==2.9.7
 pgvector==0.2.2

--- a/lib/shared/shared-asset-bundler.ts
+++ b/lib/shared/shared-asset-bundler.ts
@@ -50,6 +50,7 @@ export class SharedAssetBundler extends Construct {
   }
 
   bundleWithAsset(assetPath: string): Asset {
+    console.log(assetPath, calculateHash([assetPath, ...this.sharedAssets]));
     const asset = new aws_s3_assets.Asset(
       this,
       md5hash(assetPath).slice(0, 6),

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -86,12 +86,12 @@ export interface SystemConfig {
     customProviderType?: string;
     customSAML?: {
       metadataDocumentUrl?: string;
-    }
+    };
     customOIDC?: {
       OIDCClient?: string;
       OIDCSecret?: string;
       OIDCIssuerURL?: string;
-    }
+    };
     cognitoDomain?: string;
   };
   cfGeoRestrictEnable: boolean;
@@ -101,6 +101,11 @@ export interface SystemConfig {
     region?: SupportedRegion;
     endpointUrl?: string;
     roleArn?: string;
+    guardrails?: {
+      enabled: boolean;
+      identifier: string;
+      version: string;
+    };
   };
   llms: {
     sagemaker: SupportedSageMakerModels[];

--- a/package-lock.json
+++ b/package-lock.json
@@ -3491,12 +3491,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -4000,9 +4000,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds supports for Bedrock Guardrails to the Chatbot. You create a Guardrail outside of the chatbot (eg via console, CloudFormation, CDK) and then you add the Guardrail Identifier and Version when configuring the chatbot.

With this PR we have also restructured the config command, moving all advanced configuration options at the end and making them optional.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
