### PR TITLE
Added code to create bedrock vpc endpoint for bedrock as the models list endpoints timesout

### DIFF
--- a/lib/shared/index.ts
+++ b/lib/shared/index.ts
@@ -149,10 +149,16 @@ export class Shared extends Construct {
           if (props.config.bedrock?.region !== cdk.Stack.of(this).region) {
             throw new Error(`Bedrock is only supported in the same region as the stack when using private website (Bedrock region: ${props.config.bedrock?.region}, Stack region: ${cdk.Stack.of(this).region}).`);
           }
+          
           vpc.addInterfaceEndpoint("BedrockEndpoint", {
-            service: new ec2.InterfaceVpcEndpointService('com.amazonaws.'+cdk.Aws.REGION+'.bedrock-runtime', 443),
-            privateDnsEnabled: true
+            service: ec2.InterfaceVpcEndpointAwsService.BEDROCK,
           });
+          
+          vpc.addInterfaceEndpoint("BedrockRuntimeEndpoint", {
+            service: ec2.InterfaceVpcEndpointAwsService.BEDROCK_RUNTIME,
+          });
+          
+          
         }
 
         // Create VPC Endpoint for Kendra


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Created Bedrock endpoint incase of private deployment as the bedrock endpoint helps to list the models. The models timesout if the VPC endpoint doesnt exist


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
