### PR TITLE
Fix Kendra character count validation error

### DIFF
--- a/lib/shared/layers/python-sdk/python/genai_core/kendra/query.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/kendra/query.py
@@ -21,6 +21,7 @@ def query_workspace_kendra(
 
     kendra = get_kendra_client_for_index(kendra_index_id)
     limit = max(1, min(100, limit))
+    query = query.strip()[0:999]
 
     if kendra_index_external or kendra_use_all_data:
         result = kendra.retrieve(


### PR DESCRIPTION
*Issue #, if available:*

Kendra retrieval fails when the query has more than 1000 characters.
The error can be reproduced by choosing a workspace that uses the Kendra engine and sending a message longer than 1000 characters.

![kendra_character_count_validation_error](https://github.com/aws-samples/aws-genai-llm-chatbot/assets/141761542/635d54d9-89d5-4ca3-a1bd-67012023ac68)

*Description of changes:*
An attempt to solve this problem would be to remove any leading and trailing whitespace characters and send only the first 1000 characters as query text.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
