### PR TITLE
fix: typo in documentation anchor link

### DIFF
--- a/docs/guide/deploy.md
+++ b/docs/guide/deploy.md
@@ -26,7 +26,7 @@ To do this, run the following command from the Cloud9 terminal:
 
 See the documentation for more details on [environment resize](https://docs.aws.amazon.com/cloud9/latest/user-guide/move-environment.html#move-environment-resize).
 
-You can now proceed with the [deployment](#deployement)
+You can now proceed with the [deployment](#deployment)
 
 ### Github Codespaces
 


### PR DESCRIPTION
*Issue #:* N/A

*Description of changes:*
An link that points to an anchor was mistyped. This should fix that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
