### PR TITLE
Do not create SageMaker and StepFunctions endpoints when not needed

### DIFF
--- a/lib/shared/index.ts
+++ b/lib/shared/index.ts
@@ -108,10 +108,12 @@ export class Shared extends Construct {
       });
 
       // Create VPC Endpoint for SageMaker Runtime
-      vpc.addInterfaceEndpoint("SageMakerRuntimeEndpoint", {
-        service: ec2.InterfaceVpcEndpointAwsService.SAGEMAKER_RUNTIME,
-        open: true,
-      });
+      if (props.config.llms.sagemaker.length > 0){
+        vpc.addInterfaceEndpoint("SageMakerRuntimeEndpoint", {
+          service: ec2.InterfaceVpcEndpointAwsService.SAGEMAKER_RUNTIME,
+          open: true,
+        });
+      }
 
       if (props.config.privateWebsite) {
         // Create VPC Endpoint for AppSync
@@ -129,10 +131,11 @@ export class Shared extends Construct {
             service: ec2.InterfaceVpcEndpointAwsService.SNS,
         });
 
-        // Create VPC Endpoint for Step Functions
-        vpc.addInterfaceEndpoint("StepFunctionsEndpoint", {
-            service: ec2.InterfaceVpcEndpointAwsService.STEP_FUNCTIONS,
-        });
+        if(props.config.rag.enabled) {
+          vpc.addInterfaceEndpoint("StepFunctionsEndpoint", {
+              service: ec2.InterfaceVpcEndpointAwsService.STEP_FUNCTIONS,
+          });
+        }
 
         // Create VPC Endpoint for SSM
         vpc.addInterfaceEndpoint("SSMEndpoint", {


### PR DESCRIPTION
*Issue #: N/A*

*Description of changes:*
Don't create the Sagemaker endpoint if sagemaker is not enabled in config.
Don't create the StepFunctions endpoint if RAG is not enabled in config.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
