### PR TITLE
fix(api): Fixed getDocument(s) endpoint errors

### DIFF
--- a/lib/chatbot-api/functions/api-handler/routes/documents.py
+++ b/lib/chatbot-api/functions/api-handler/routes/documents.py
@@ -307,13 +307,7 @@ def update_rss_feed(input: dict):
 
 
 def _convert_document(document: dict):
-    if "crawler_properties" in document:
-        document["crawler_properties"] = {
-            "followLinks": document["crawler_properties"]["follow_links"],
-            "limit": document["crawler_properties"]["limit"],
-            "contentTypes": document["crawler_properties"]["content_types"],
-        }
-    return {
+    converted_document = {
         "id": document["document_id"],
         "workspaceId": document["workspace_id"],
         "type": document["document_type"],
@@ -328,12 +322,13 @@ def _convert_document(document: dict):
         "createdAt": document["created_at"],
         "updatedAt": document.get("updated_at", None),
         "rssFeedId": document.get("rss_feed_id", None),
-        "rssLastCheckedAt": document.get("rss_last_checked", None),
-        "crawlerProperties": {
+        "rssLastCheckedAt": document.get("rss_last_checked", None)
+    }
+    if "crawler_properties" in document:
+        converted_document['crawlerProperties'] = {
             "followLinks": document.get("crawler_properties").get("follow_links", None),
             "limit": document.get("crawler_properties").get("limit", None),
             "contentTypes": document.get("crawler_properties").get("content_types", None),
         }
-        if document.get("crawler_properties", None) != None
-        else None,
-    }
+    
+    return converted_document

--- a/lib/chatbot-api/functions/api-handler/routes/documents.py
+++ b/lib/chatbot-api/functions/api-handler/routes/documents.py
@@ -65,9 +65,11 @@ class GetDocumentRequest(BaseModel):
     workspaceId: str
     documentId: str
 
+
 class DeleteDocumentRequest(BaseModel):
     workspaceId: str
     documentId: str
+
 
 class GetRssPostsRequest(BaseModel):
     workspaceId: str
@@ -135,13 +137,17 @@ def get_documents(input: dict):
         "lastDocumentId": result["last_document_id"],
     }
 
+
 @router.resolver(field_name="deleteDocument")
 @tracer.capture_method
 def delete_document(input: dict):
     request = DeleteDocumentRequest(**input)
-    result = genai_core.documents.delete_document(request.workspaceId, request.documentId)
-    
+    result = genai_core.documents.delete_document(
+        request.workspaceId, request.documentId
+    )
+
     return result
+
 
 @router.resolver(field_name="getDocument")
 @tracer.capture_method
@@ -322,13 +328,15 @@ def _convert_document(document: dict):
         "createdAt": document["created_at"],
         "updatedAt": document.get("updated_at", None),
         "rssFeedId": document.get("rss_feed_id", None),
-        "rssLastCheckedAt": document.get("rss_last_checked", None)
+        "rssLastCheckedAt": document.get("rss_last_checked", None),
     }
     if "crawler_properties" in document:
-        converted_document['crawlerProperties'] = {
+        converted_document["crawlerProperties"] = {
             "followLinks": document.get("crawler_properties").get("follow_links", None),
             "limit": document.get("crawler_properties").get("limit", None),
-            "contentTypes": document.get("crawler_properties").get("content_types", None),
+            "contentTypes": document.get("crawler_properties").get(
+                "content_types", None
+            ),
         }
-    
+
     return converted_document


### PR DESCRIPTION
When attempting to view details of an RSS feed, the getDocument endpoint was throwing an error around crawler_properties, potentially due to a merge in the past. The updated code properly handles if crawler properties are applied. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
