### PR TITLE
fix: Token order during streaming

### DIFF
--- a/lib/user-interface/react-app/src/components/chatbot/chat-input-panel.tsx
+++ b/lib/user-interface/react-app/src/components/chatbot/chat-input-panel.tsx
@@ -47,6 +47,7 @@ import {
   ChatInputState,
   ImageFile,
   ChatBotModelInterface,
+  ChatBotToken,
 } from "./types";
 import { sendQuery } from "../../graphql/mutations";
 import {
@@ -115,6 +116,7 @@ export default function ChatInputPanel(props: ChatInputPanelProps) {
   useEffect(() => {
     async function subscribe() {
       console.log("Subscribing to AppSync");
+      const messageTokens: { [key: string]: ChatBotToken[] } = {};
       setReadyState(ReadyState.CONNECTING);
       const sub = await API.graphql<
         GraphQLSubscription<ReceiveMessagesSubscription>
@@ -134,10 +136,12 @@ export default function ChatInputPanel(props: ChatInputPanelProps) {
               console.log("Heartbeat pong!");
               return;
             }
+
             updateMessageHistoryRef(
               props.session.id,
               messageHistoryRef.current,
-              response
+              response,
+              messageTokens
             );
 
             if (

--- a/lib/user-interface/react-app/src/components/chatbot/chat-message.tsx
+++ b/lib/user-interface/react-app/src/components/chatbot/chat-message.tsx
@@ -67,10 +67,24 @@ export default function ChatMessage(props: ChatMessageProps) {
     }
   }, [message]);
 
-  const content =
-    props.message.content && props.message.content.length > 0
-      ? props.message.content
-      : props.message.tokens?.map((v) => v.value).join("");
+  let content = "";
+  if (props.message.content && props.message.content.length > 0) {
+    // Message is final
+    content = props.message.content;
+  } else if (props.message.tokens && props.message.tokens.length > 0) {
+    // Streaming in progess. Hides the tokens out of sequence
+    // If I have 1,2,4, it would only display 1,2.
+    let currentSequence: number | undefined = undefined;
+    for (const token of props.message.tokens) {
+      if (
+        currentSequence === undefined ||
+        currentSequence + 1 == token.sequenceNumber
+      ) {
+        currentSequence = token.sequenceNumber;
+        content += token.value;
+      }
+    }
+  }
 
   return (
     <div>

--- a/lib/user-interface/react-app/src/components/chatbot/multi-chat.tsx
+++ b/lib/user-interface/react-app/src/components/chatbot/multi-chat.tsx
@@ -38,6 +38,7 @@ import {
   ChatBotHeartbeatRequest,
   ChatBotModelInterface,
   FeedbackData,
+  ChatBotToken,
 } from "./types";
 import { LoadingStatus, ModelInterface } from "../../common/types";
 import { getSelectedModelMetadata, updateMessageHistoryRef } from "./utils";
@@ -232,6 +233,7 @@ export default function MultiChat() {
 
   function subscribe(sessionId: string): ZenObservable.Subscription {
     console.log("Subscribing to AppSync");
+    const messageTokens: { [key: string]: ChatBotToken[] } = {};
     const sub = API.graphql<GraphQLSubscription<ReceiveMessagesSubscription>>({
       query: receiveMessages,
       variables: {
@@ -243,7 +245,6 @@ export default function MultiChat() {
         const data = value.data!.receiveMessages?.data;
         if (data !== undefined && data !== null) {
           const response: ChatBotMessageResponse = JSON.parse(data);
-          console.log(JSON.stringify(response));
           if (response.action === ChatBotAction.Heartbeat) {
             console.log("Heartbeat pong!");
             return;
@@ -257,7 +258,8 @@ export default function MultiChat() {
             updateMessageHistoryRef(
               session.id,
               session.messageHistory,
-              response
+              response,
+              messageTokens
             );
             if ((response.action = ChatBotAction.FinalResponse)) {
               session.running = false;

--- a/lib/user-interface/react-app/src/components/chatbot/utils.ts
+++ b/lib/user-interface/react-app/src/components/chatbot/utils.ts
@@ -5,6 +5,7 @@ import {
   ChatBotHistoryItem,
   ChatBotMessageResponse,
   ChatBotMessageType,
+  ChatBotToken,
 } from "./types";
 import { ChatSession } from "./multi-chat";
 import { SelectProps } from "@cloudscape-design/components";
@@ -116,7 +117,8 @@ export function updateMessageHistory(
 export function updateMessageHistoryRef(
   sessionId: string,
   messageHistory: ChatBotHistoryItem[],
-  response: ChatBotMessageResponse
+  response: ChatBotMessageResponse,
+  messageTokens: { [key: string]: ChatBotToken[] }
 ) {
   if (response.data?.sessionId !== sessionId) return;
 
@@ -135,8 +137,12 @@ export function updateMessageHistoryRef(
       messageHistory.length > 0 &&
       messageHistory.at(-1)?.type !== ChatBotMessageType.Human
     ) {
-      const lastMessage = messageHistory.at(-1)!;
-      lastMessage.tokens = lastMessage.tokens ?? [];
+      const lastMessageIndex = messageHistory.length - 1;
+      const lastMessage = messageHistory[lastMessageIndex]!;
+      if (messageTokens[lastMessageIndex] === undefined) {
+        messageTokens[lastMessageIndex] = [];
+      }
+      lastMessage.tokens = messageTokens[lastMessageIndex];
       if (hasToken) {
         lastMessage.tokens.push(token);
       }


### PR DESCRIPTION
*Issue #, if available:*
#501

*Description of changes:*
Fixes two issues:
* Only shows a token if the previous ones are available (so it only adds the words at the end)
* Fix token missed. This happens when receiving 2 tokens in parallel. The fix is to move the reference of `lastMessage.tokens` out of `updateMessageHistoryRef` (so it uses the same array)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

https://github.com/user-attachments/assets/4e4b5a6b-a67d-40a0-9d88-8181244b541b