### PR TITLE
`scripts/cloud9-resize.sh` fails in Ubuntu 22.04, added check for OS string

### DIFF
--- a/scripts/cloud9-resize.sh
+++ b/scripts/cloud9-resize.sh
@@ -5,7 +5,7 @@ SIZE=${2:-120}
 
 VERSIONID=$(awk /VERSION_ID=/ /etc/os-release |cut -d \" -f 2)
 
-if [[ "$VERSIONID" == "2023" ]]; then
+if [[ "$VERSIONID" == "2023" || "$VERSIONID" == "22.04" ]]; then
   # Get the METADATA INSTANCE V2 token
   TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
   # Get the ID of the environment host Amazon EC2 instance.


### PR DESCRIPTION
Following instructions in the [deploy](https://aws-samples.github.io/aws-genai-llm-chatbot/guide/deploy.html) section of the documentation: 

- I deployed a Cloud9 instance in `ap-southeast-2` and chose Ubuntu as the AMI
- I ran `scripts/cloud9-resize.sh` to resize my volume to 100GB
- The script fails with `EBS Volumes: The selected volume is invalid.`

I had a look at the script and it checks for a version string of `2023`, but the version string in this AMI is `2022.04`:

```
$ cat /etc/os-release
PRETTY_NAME="Ubuntu 22.04.4 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.4 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
```

```bash
$ awk /VERSION_ID=/ /etc/os-release |cut -d \" -f 2
22.04
```

I have updated the script to check for this version string, and it seems to work ok now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
