### PR TITLE
chore: Get base docker image from Public ECR

### DIFF
--- a/lib/shared/alpine-zip/Dockerfile
+++ b/lib/shared/alpine-zip/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM public.ecr.aws/docker/library/alpine
 RUN apk add zip
 RUN adduser -D default
 USER default

--- a/lib/shared/web-crawler-dockerfile
+++ b/lib/shared/web-crawler-dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine
+FROM public.ecr.aws/docker/library/python:3.10-alpine
 
 WORKDIR /app
 COPY web-crawler-batch-job/requirements.txt requirements.txt


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Replace docker base image location to use Amazon Public ECR to prevent docker hub throttling when the build is running in an AWS account.

Images
https://gallery.ecr.aws/docker/library/python
https://gallery.ecr.aws/docker/library/alpine

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
