### PR TITLE
feat: Reduce layer size to reduce cold start

### DIFF
--- a/lib/shared/shared-asset-bundler.ts
+++ b/lib/shared/shared-asset-bundler.ts
@@ -64,6 +64,7 @@ export class SharedAssetBundler extends Construct {
           command: [
             "zip",
             "-r",
+            "-9",
             path.posix.join("/asset-output", "asset.zip"),
             ".",
           ],

--- a/pytest_requirements.txt
+++ b/pytest_requirements.txt
@@ -11,4 +11,5 @@ selenium==4.16
 pdfplumber==0.11.0
 pyopenssl==24.2.1
 cryptography==42.0.4
+boto3
 -r lib/shared/layers/common/requirements.txt


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Reducing the layer size reduces the init time. (5s ->3.5s)

To reduce the layer size
 - Remove boto 3 and use the one available in the runtime
 - Remove SQL Alchemy which is only needed when using SQL based memory in langchain.
 - Remove `pyc` files

The large package part of this project is `numpy` needed by `langchain`. A future improvement could be to try to reduce its size.

Another improvement could be to increase the memory(and cpu). 512->1024 would reduce it further by  ~0.3s

*Testing*
Ran integration tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
