### PR TITLE
fix: documentation wording + revert a change causing Aurora re-creation

### DIFF
--- a/docs/documentation/monitoring.md
+++ b/docs/documentation/monitoring.md
@@ -1,26 +1,26 @@
 # Monitoring
-By default, the project will create a [Amazon CloudWatch Dashboard](https://console.aws.amazon.com/cloudwatch). This Dashboard is created using the library [cdk-monitoring-constructs](https://github.com/cdklabs/cdk-monitoring-constructs) and it is recommended to update the metrics you tracks based on your project needs.
+By default, the project will create an [Amazon CloudWatch Dashboard](https://console.aws.amazon.com/cloudwatch). This dashboard is created using the library [cdk-monitoring-constructs](https://github.com/cdklabs/cdk-monitoring-constructs) and it is recommended to update the metrics you track based on your project needs.
 
 The dashboard is created in `lib/monitoring/index.ts`
 
-During the configuration set, the advanced settings allows you to enable advance monitoring which will do the following:
-* [Enable AWS X-Ray](https://docs.aws.amazon.com/xray/latest/devguide/aws-xray.html) which will collect traces availbale by opening the [Trace Map](https://docs.aws.amazon.com/xray/latest/devguide/xray-console-servicemap.html) from the CloudWatch console.
-* Generate a custom metric per LLM model used using Amazon Bedrock allowing you to track token usage. This metrics are available in the dashboard. These metrics are created using [Cloudwatch filters](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/MonitoringLogData.html).
+During the configuration setup, the advanced monitoring setting will enable the following:
+* [AWS X-Ray](https://docs.aws.amazon.com/xray/latest/devguide/aws-xray.html) will collect traces that can be viewed by opening the [Trace Map](https://docs.aws.amazon.com/xray/latest/devguide/xray-console-servicemap.html) from the CloudWatch console.
+* Generate a custom metric per LLM model used (Bedrock only) allowing you to track the token usage. These metrics are available in the dashboard and are created using [Cloudwatch filters](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/MonitoringLogData.html).
 * Create sample CloudWatch Alarms. 
 
-***Cost***: Be mindful of the costs associated with AWS resources, enabling advance motoring is [adding custom metrics, alarms](https://aws.amazon.com/cloudwatch/pricing/) and [AWS X-Ray traces](https://aws.amazon.com/xray/pricing/).
+***Cost***: Be mindful of the costs associated with AWS resources, as enabling advanced motoring is [adding custom metrics, alarms](https://aws.amazon.com/cloudwatch/pricing/) and [AWS X-Ray traces](https://aws.amazon.com/xray/pricing/).
 
 ## Recommended changes (Advanced monitoring)
 
-### Recevie alerts
+### Receive alerts
 The default setup is monitoring key resources such as the error rates of the APIs or the dead letter queues (if not empty, the processing of LLM requests failed). All these alarms can be viewed from the Amazon CloudWatch console.
 
-The alarms state is monitoring by a [composite alarm](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Create_Composite_Alarm.html) which will send an event to an SNS Topic if any alarm is active.
+The alarms are part of a [composite alarm](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Create_Composite_Alarm.html) which will send an event to an SNS Topic if any alarm is active.
 
-To receive notifications, add a [subscription](https://docs.aws.amazon.com/sns/latest/dg/sns-create-subscribe-endpoint-to-topic.html) (manually or in `lib/monitoring/index.ts`) to the topic listed in the Cloudformation output `CompositeAlarmTopicOutput`.
+To receive notifications, add a [subscription](https://docs.aws.amazon.com/sns/latest/dg/sns-create-subscribe-endpoint-to-topic.html) (manually or in `lib/monitoring/index.ts`) to the topic listed in the CloudFormation output `CompositeAlarmTopicOutput` (When deploying).
 
 ### Update alarms and their thresholds
-The alarms listed in `lib/monitoring/index.ts` are example and they should be updated to match your project needs. Please refer to the following [project describing](https://github.com/cdklabs/cdk-monitoring-constructs) how to add/update the alarms.
+The alarms listed in `lib/monitoring/index.ts` are examples and they should be updated to match your project needs. Please refer to the following [project describing](https://github.com/cdklabs/cdk-monitoring-constructs) how to add/update the alarms.
 
 ### Review AWS X-Ray sampling
 Consider updating the default [AWS X-Ray sampling rules](https://docs.aws.amazon.com/xray/latest/devguide/xray-console-sampling.html) to define the amount of data recorded

--- a/lib/rag-engines/aurora-pgvector/index.ts
+++ b/lib/rag-engines/aurora-pgvector/index.ts
@@ -31,8 +31,8 @@ export class AuroraPgVector extends Construct {
         version: rds.AuroraPostgresEngineVersion.VER_15_3,
       }),
       storageEncryptionKey: props.shared.kmsKey,
-      // Always setting it to true would be a breaking change.
-      storageEncrypted: props.shared.kmsKey ? true : false,
+      // Always setting it to true would be a breaking change. (Undefined to prevent re-creating)
+      storageEncrypted: props.shared.kmsKey ? true : undefined,
       removalPolicy:
         props.config.retainOnDelete === true
           ? cdk.RemovalPolicy.SNAPSHOT

--- a/tests/chatbot-api/__snapshots__/chatbot-api-construct.test.ts.snap
+++ b/tests/chatbot-api/__snapshots__/chatbot-api-construct.test.ts.snap
@@ -4974,7 +4974,6 @@ schema {
           "MaxCapacity": 2,
           "MinCapacity": 0.5,
         },
-        "StorageEncrypted": false,
         "VpcSecurityGroupIds": [
           {
             "Fn::GetAtt": [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Proofread the new documentation page.
* Revert `StorageEncrypted` change. Setting it  is causing cloudformation to re-create the cluster.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
