### PR TITLE
bug: Exclude internal calls from WAF rate limiter

### DIFF
--- a/tests/__snapshots__/cdk-app.test.ts.snap
+++ b/tests/__snapshots__/cdk-app.test.ts.snap
@@ -4057,6 +4057,29 @@ schema {
       },
       "Type": "AWS::IAM::Policy",
     },
+    "ChatBotApiVPCPublicIPsAE6206D3": {
+      "Properties": {
+        "Addresses": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Fn::GetAtt": [
+                    "SharedVPCpublicSubnet1EIPA9E2FC1C",
+                    "PublicIp",
+                  ],
+                },
+                "/32",
+              ],
+            ],
+          },
+        ],
+        "IPAddressVersion": "IPV4",
+        "Scope": "REGIONAL",
+      },
+      "Type": "AWS::WAFv2::IPSet",
+    },
     "ChatBotApiWafAppsync9FEB4E22": {
       "Properties": {
         "DefaultAction": {
@@ -4143,6 +4166,28 @@ schema {
               "CloudWatchMetricsEnabled": true,
               "MetricName": "LimitRequestsPerIP",
               "SampledRequestsEnabled": true,
+            },
+          },
+          {
+            "Action": {
+              "Allow": {},
+            },
+            "Name": "AllowInternalCalls",
+            "Priority": 2,
+            "Statement": {
+              "IPSetReferenceStatement": {
+                "Arn": {
+                  "Fn::GetAtt": [
+                    "ChatBotApiVPCPublicIPsAE6206D3",
+                    "Arn",
+                  ],
+                },
+              },
+            },
+            "VisibilityConfig": {
+              "CloudWatchMetricsEnabled": false,
+              "MetricName": "AllowInternalCalls",
+              "SampledRequestsEnabled": false,
             },
           },
         ],

--- a/tests/chatbot-api/__snapshots__/chatbot-api-construct.test.ts.snap
+++ b/tests/chatbot-api/__snapshots__/chatbot-api-construct.test.ts.snap
@@ -4119,6 +4119,29 @@ schema {
       },
       "Type": "AWS::IAM::Policy",
     },
+    "ChatBotApiConstructVPCPublicIPs5C63CEBB": {
+      "Properties": {
+        "Addresses": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Fn::GetAtt": [
+                    "SharedVPCpublicSubnet1EIPA9E2FC1C",
+                    "PublicIp",
+                  ],
+                },
+                "/32",
+              ],
+            ],
+          },
+        ],
+        "IPAddressVersion": "IPV4",
+        "Scope": "REGIONAL",
+      },
+      "Type": "AWS::WAFv2::IPSet",
+    },
     "ChatBotApiConstructWafAppsyncE6AACFFE": {
       "Properties": {
         "DefaultAction": {
@@ -4205,6 +4228,28 @@ schema {
               "CloudWatchMetricsEnabled": true,
               "MetricName": "LimitRequestsPerIP",
               "SampledRequestsEnabled": true,
+            },
+          },
+          {
+            "Action": {
+              "Allow": {},
+            },
+            "Name": "AllowInternalCalls",
+            "Priority": 2,
+            "Statement": {
+              "IPSetReferenceStatement": {
+                "Arn": {
+                  "Fn::GetAtt": [
+                    "ChatBotApiConstructVPCPublicIPs5C63CEBB",
+                    "Arn",
+                  ],
+                },
+              },
+            },
+            "VisibilityConfig": {
+              "CloudWatchMetricsEnabled": false,
+              "MetricName": "AllowInternalCalls",
+              "SampledRequestsEnabled": false,
             },
           },
         ],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The internal calls sending chunks (LLM Response Streaming) to the end user was reaching the WAF throttling limit added in #581.

To prevent this, the change excludes the VPC IPs from the throttling limit.

*Testing*
Check WAF Metrics + requested large output from the model with streaming.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
