### PR TITLE
bug: Fix cli stopping when using Bedrock KB

### DIFF
--- a/cli/magic-config.ts
+++ b/cli/magic-config.ts
@@ -838,6 +838,7 @@ async function processCreateOptions(options: any): Promise<void> {
       choices: embeddingModels.map((m) => ({ name: m.name, value: m })),
       initial: options.defaultEmbedding,
       validate(value: string) {
+        if ((this as any).skipped) return true;
         const embeding = embeddingModels.find((i) => i.name === value);
         if (
           answers.enableRag &&


### PR DESCRIPTION
*Issue #, if available:* #592

*Description of changes:*
The cli library `enquirer` silently exits when the question is skipped and invalid. Added a check.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
