### PR TITLE
Remove redundant "usage" metadata

### DIFF
--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/base/base.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/base/base.py
@@ -320,7 +320,6 @@ class ModelAdapter:
             "userId": self.user_id,
             "documents": workspace_documents,
             "prompts": clean_prompts,
-            "usage": self.callback_handler.usage,
         }
 
         if is_admin_role(user_groups):


### PR DESCRIPTION
*Issue #, if available:*

#620

*Description of changes:*

Resolve the issue 

```
Additional kwargs key total_tokens already exists in left dict and value has unsupported type <class 'decimal.Decimal'>.
```

After removing, "usage" metadata is still being tracked in succession

<img width="600" alt="image" src="https://github.com/user-attachments/assets/32abe44f-4522-4eca-bcf0-5d9f2a4b6287" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/15542539-9004-4bbc-885a-38cad31f34f6" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/2df2716f-6e89-472d-9169-2fcd6a941177" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/872794de-c7a3-4e24-ac16-5406c6fac7f7" />


