### PR TITLE
feat(metadata): Add metadata output for Nexus integration

### DIFF
--- a/aws-genai-llm-chatbot/modules/chatbot/deployspec.yaml
+++ b/aws-genai-llm-chatbot/modules/chatbot/deployspec.yaml
@@ -11,7 +11,7 @@ deploy:
         - npm run config -- --non-interactive --env-prefix NEXUS_PARAMETER_
         - npm run deploy -- --require-approval never --progress events --outputs-file ./cdk-exports.json -v
         - cat cdk-exports.json
-        - seedfarmer metadata convert -f cdk-exports.json || true
+        - seedfarmer metadata convert -f cdk-exports.json -jq .${NEXUS_PARAMETER_PREFIX}GenAIChatBotStack.metadata || true
 destroy:
   phases:
     build:

--- a/lib/aws-genai-llm-chatbot-stack.ts
+++ b/lib/aws-genai-llm-chatbot-stack.ts
@@ -626,5 +626,28 @@ export class AwsGenAILLMChatbotStack extends cdk.Stack {
         ]
       );
     }
+
+    new cdk.CfnOutput(this, "metadata", {
+      value: JSON.stringify({
+        ChatbotUserInterfaceDomainName: userInterface.cloudFrontDistribution
+          ?.distributionDomainName
+          ? `https://${userInterface.cloudFrontDistribution?.distributionDomainName}`
+          : "",
+        ChatbotUserPoolId: authentication.userPool.userPoolId,
+        ChatbotUserPoolClientId: authentication.userPoolClient.userPoolClientId,
+        ChatbotUserPoolLink: `https://${cdk.Stack.of(this).region}.console.aws.amazon.com/cognito/v2/idp/user-pools/${authentication.userPool.userPoolId}/users?region=${cdk.Stack.of(this).region}`,
+        ChatbotGraphqlApiUrl: chatBotApi.graphqlApi.graphqlUrl,
+        ChatbotGraphQLApiId: chatBotApi.graphqlApi.apiId,
+        ChatbotApiKeysSecretName: shared.apiKeysSecret.secretName,
+        ChatbotLoadBalancerDNS: userInterface.privateWebsite
+          ? userInterface.privateWebsite?.loadBalancer.loadBalancerDnsName
+          : "",
+        ChatbotDomain: userInterface.publishedDomain,
+        ChatbotCompositeAlarmTopicOutput:
+          monitoringConstruct.compositeAlarmTopic
+            ? monitoringConstruct.compositeAlarmTopic.topicName
+            : "",
+      }),
+    });
   }
 }

--- a/lib/user-interface/index.ts
+++ b/lib/user-interface/index.ts
@@ -31,6 +31,7 @@ export interface UserInterfaceProps {
 export class UserInterface extends Construct {
   public readonly publishedDomain: string;
   public readonly cloudFrontDistribution?: cf.IDistribution;
+  public readonly privateWebsite?: PrivateWebsite;
 
   constructor(scope: Construct, id: string, props: UserInterfaceProps) {
     super(scope, id);
@@ -73,7 +74,7 @@ export class UserInterface extends Construct {
     let redirectSignIn: string;
 
     if (props.config.privateWebsite) {
-      new PrivateWebsite(this, "PrivateWebsite", {
+      this.privateWebsite = new PrivateWebsite(this, "PrivateWebsite", {
         ...props,
         websiteBucket: websiteBucket,
       });

--- a/lib/user-interface/private-website.ts
+++ b/lib/user-interface/private-website.ts
@@ -22,6 +22,8 @@ export interface PrivateWebsiteProps {
 }
 
 export class PrivateWebsite extends Construct {
+  public readonly loadBalancer: elbv2.ApplicationLoadBalancer;
+
   constructor(scope: Construct, id: string, props: PrivateWebsiteProps) {
     super(scope, id);
 
@@ -154,6 +156,7 @@ export class PrivateWebsite extends Construct {
         subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
       }),
     });
+    this.loadBalancer = loadBalancer;
 
     const albLogBucket = new s3.Bucket(this, "ALBLoggingBucket", {
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,

--- a/tests/__snapshots__/cdk-app.test.ts.snap
+++ b/tests/__snapshots__/cdk-app.test.ts.snap
@@ -279,6 +279,103 @@ exports[`snapshot test with CMK 1`] = `
         ],
       },
     },
+    "metadata": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "{"ChatbotUserInterfaceDomainName":"","ChatbotUserPoolId":"",
+            {
+              "Ref": "AuthenticationUserPool28698864",
+            },
+            "","ChatbotUserPoolClientId":"",
+            {
+              "Ref": "AuthenticationUserPoolUserPoolClient8AE1704E",
+            },
+            "","ChatbotUserPoolLink":"https://us-east-1.console.aws.amazon.com/cognito/v2/idp/user-pools/",
+            {
+              "Ref": "AuthenticationUserPool28698864",
+            },
+            "/users?region=us-east-1","ChatbotGraphqlApiUrl":"",
+            {
+              "Fn::GetAtt": [
+                "ChatBotApiChatbotApiBABF9B87",
+                "GraphQLUrl",
+              ],
+            },
+            "","ChatbotGraphQLApiId":"",
+            {
+              "Fn::GetAtt": [
+                "ChatBotApiChatbotApiBABF9B87",
+                "ApiId",
+              ],
+            },
+            "","ChatbotApiKeysSecretName":"",
+            {
+              "Fn::Join": [
+                "-",
+                [
+                  {
+                    "Fn::Select": [
+                      0,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "SharedApiKeysSecret9EA666ED",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    "Fn::Select": [
+                      1,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "SharedApiKeysSecret9EA666ED",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+            "","ChatbotLoadBalancerDNS":"",
+            {
+              "Fn::GetAtt": [
+                "UserInterfacePrivateWebsiteALB67ED856F",
+                "DNSName",
+              ],
+            },
+            "","ChatbotDomain":"","ChatbotCompositeAlarmTopicOutput":""}",
+          ],
+        ],
+      },
+    },
   },
   "Parameters": {
     "BootstrapVersion": {


### PR DESCRIPTION
*Description of changes:*

Add a new CfnOutput with metadata containing key information about the deployed resources, including:
- User interface domain name and CloudFront distribution
- Cognito user pool details
- GraphQL API information
- API keys secret name
- Load balancer DNS for private website deployments

Update deployspec.yaml to extract the metadata using jq from the specific stack output. Expose the privateWebsite and loadBalancer properties to make them accessible for the metadata output.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
