### PR TITLE
fix: handle LLM handlers log setup gracefully

### DIFF
--- a/aws-genai-llm-chatbot/modules/chatbot/deployspec.yaml
+++ b/aws-genai-llm-chatbot/modules/chatbot/deployspec.yaml
@@ -6,10 +6,11 @@ deploy:
        - npx @aws-amplify/cli codegen add --yes
     build:
       commands:
+        - mkdir -p /root/.cdk/cache
         - env | grep NEXUS | sort | awk -F= '{printf "%-30s = %s\n", $1, $2}'
         - npm run tsc
         - npm run config -- --non-interactive --env-prefix NEXUS_PARAMETER_
-        - npm run deploy -- --require-approval never --progress events --outputs-file ./cdk-exports.json -v
+        - npm run deploy -- --require-approval never --progress events --outputs-file ./cdk-exports.json -v --no-notices
         - cat cdk-exports.json
         - seedfarmer metadata convert -f cdk-exports.json -jq .${NEXUS_PARAMETER_PREFIX}GenAIChatBotStack.metadata || true
 destroy:

--- a/lib/monitoring/index.ts
+++ b/lib/monitoring/index.ts
@@ -97,15 +97,18 @@ export class Monitoring extends Construct {
         ])
       )
     );
-    monitoring.addSegment(
-      new SingleWidgetDashboardSegment(
-        this.getLogsWidget(
-          "LLM Request Handlers Logs:",
-          props.llmRequestHandlersLogGroups,
-          []
+    // Only add LLM Request Handlers Logs widget if there are log groups
+    if (props.llmRequestHandlersLogGroups.length > 0) {
+      monitoring.addSegment(
+        new SingleWidgetDashboardSegment(
+          this.getLogsWidget(
+            "LLM Request Handlers Logs:",
+            props.llmRequestHandlersLogGroups,
+            []
+          )
         )
-      )
-    );
+      );
+    }
 
     if (props.advancedMonitoring) {
       this.addMetricFilter(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fixed issue with CDK notices in CI/CD:
- ```Failed to store notices in the cache: Error: ENOENT: no such file or directory, open '/root/.cdk/cache/notices.json'``` 
- Handled llm handler log widget setup gracefully, this is needed when bedrock is disabled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
