### PR TITLE
fix(auth): enforce workspace manager access control

### DIFF
--- a/lib/authentication/index.ts
+++ b/lib/authentication/index.ts
@@ -47,7 +47,7 @@ export class Authentication extends Construct {
       getConstructId("WorkspaceManagerGroup", config),
       {
         userPoolId: userPool.userPoolId,
-        groupName: getConstructId("workspace-manager", config),
+        groupName: getConstructId("workspace_manager", config),
         description: "Workspace managers group",
       }
     );

--- a/tests/__snapshots__/cdk-app.test.ts.snap
+++ b/tests/__snapshots__/cdk-app.test.ts.snap
@@ -623,7 +623,7 @@ exports[`snapshot test with CMK 1`] = `
     "AuthenticationWorkspaceManagerGroupB3DA7503": {
       "Properties": {
         "Description": "Workspace managers group",
-        "GroupName": "workspace-manager",
+        "GroupName": "workspace_manager",
         "UserPoolId": {
           "Ref": "AuthenticationUserPool28698864",
         },

--- a/tests/authentication/__snapshots__/autentication-construct.test.ts.snap
+++ b/tests/authentication/__snapshots__/autentication-construct.test.ts.snap
@@ -217,7 +217,7 @@ exports[`snapshot test 1`] = `
     "AuthenticationConstructWorkspaceManagerGroup00E7A4D7": {
       "Properties": {
         "Description": "Workspace managers group",
-        "GroupName": "workspace-manager",
+        "GroupName": "workspace_manager",
         "UserPoolId": {
           "Ref": "AuthenticationConstructUserPoolFE5ABE04",
         },

--- a/tests/chatbot-api/__snapshots__/chatbot-api-construct.test.ts.snap
+++ b/tests/chatbot-api/__snapshots__/chatbot-api-construct.test.ts.snap
@@ -607,7 +607,7 @@ exports[`snapshot test 1`] = `
     "AuthenticationWorkspaceManagerGroupB3DA7503": {
       "Properties": {
         "Description": "Workspace managers group",
-        "GroupName": "workspace-manager",
+        "GroupName": "workspace_manager",
         "UserPoolId": {
           "Ref": "AuthenticationUserPool28698864",
         },


### PR DESCRIPTION
*Issue #, if available:*
on starting application with user having role workspace_manager, no UI is loaded. 

*Description of changes:*
in application codeline, the checks were done for workspace-manager instead of workspace_manager. Changed it for consistency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
