### PR TITLE
bugfix: Fix Nexus Gateway client authentication 

### DIFF
--- a/lib/shared/layers/python-sdk/python/genai_core/model_providers/nexus/nexus.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/model_providers/nexus/nexus.py
@@ -7,7 +7,7 @@ from abc import ABC
 from functools import lru_cache
 from typing import Any, Optional, Union
 
-from genai_core.types import EmbeddingsModel, Provider
+from genai_core.types import EmbeddingsModel, Provider, ModelInterface
 
 from ... import parameters
 from .. import ModelProvider
@@ -156,4 +156,5 @@ def _transform_nexus_model(
         "streaming": streaming,
         "inputModalities": input_modalities,
         "outputModalities": output_modalities,
+        "interface": ModelInterface.LANGCHAIN.value,
     }

--- a/lib/shared/layers/python-sdk/python/genai_core/model_providers/nexus/nexus_client.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/model_providers/nexus/nexus_client.py
@@ -114,7 +114,7 @@ class NexusGatewayClient:
         # Use client credentials
         token = self._ensure_valid_token()
         if token:
-            request_headers["Authorization"] = f"Bearer {token}"
+            request_headers["authorization-token"] = f"Bearer {token}"
         else:
             logger.error("Failed to get access token for Nexus Gateway")
             return ApiError(


### PR DESCRIPTION
*Description of changes:*

Fixed authorization error connecting with Nexus Gateway client by correcting the HTTP header name from Authorization
to authorization-token. The FastAPI route expects the hyphenated header format due to automatic underscore-to-hyphen
conversion in parameter mapping. This resolves the 401 authentication failures when calling the Nexus Gateway data plane API.

Changes:
• Updated nexus_client.py to use authorization-token header instead of Authorization
• Maintains Bearer <token> format as expected by token validator

Root cause: FastAPI converts parameter names with underscores (authorization_token) to hyphenated HTTP headers (
authorization-token), but the client was sending the standard Authorization header.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
