### PR TITLE
fix: bump aurora psql to v15.10

### DIFF
--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/base.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/base.py
@@ -54,8 +54,8 @@ class BedrockChatAdapter(ModelAdapter):
         # Pattern matches any regional prefix (us., global., eu., etc.)
         single_param_model_patterns = [
             "anthropic.claude-sonnet-4",  # Claude Sonnet 4.x (any region)
-            "anthropic.claude-opus-4",    # Claude Opus 4.x (any region)
-            "anthropic.claude-haiku-4",   # Claude Haiku 4.x (any region)
+            "anthropic.claude-opus-4",  # Claude Opus 4.x (any region)
+            "anthropic.claude-haiku-4",  # Claude Haiku 4.x (any region)
         ]
 
         model_lower = self.model_id.lower()

--- a/lib/rag-engines/aurora-pgvector/index.ts
+++ b/lib/rag-engines/aurora-pgvector/index.ts
@@ -36,7 +36,7 @@ export class AuroraPgVector extends Construct {
       engine: rds.DatabaseClusterEngine.auroraPostgres({
         // Extensions version per engine
         // https://docs.aws.amazon.com/AmazonRDS/latest/AuroraPostgreSQLReleaseNotes/AuroraPostgreSQL.Extensions.html
-        version: rds.AuroraPostgresEngineVersion.VER_15_7,
+        version: rds.AuroraPostgresEngineVersion.VER_15_10,
       }),
       storageEncryptionKey: props.shared.kmsKey,
       // Always setting it to true would be a breaking change. (Undefined to prevent re-creating)

--- a/lib/shared/layers/python-sdk/python/genai_core/model_providers/direct/provider.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/model_providers/direct/provider.py
@@ -218,8 +218,7 @@ def _list_bedrock_cris_models():
             if base_model_id in models_by_id:
                 result.append(
                     _create_bedrock_model_profile(
-                        models_by_id[base_model_id],
-                        profile_id
+                        models_by_id[base_model_id], profile_id
                     )
                 )
 

--- a/tests/__snapshots__/cdk-app.test.ts.snap
+++ b/tests/__snapshots__/cdk-app.test.ts.snap
@@ -8440,7 +8440,7 @@ schema {
         },
         "EnableIAMDatabaseAuthentication": true,
         "Engine": "aurora-postgresql",
-        "EngineVersion": "15.7",
+        "EngineVersion": "15.10",
         "KmsKeyId": {
           "Fn::GetAtt": [
             "SharedKMSKey7BCBB616",

--- a/tests/chatbot-api/__snapshots__/chatbot-api-construct.test.ts.snap
+++ b/tests/chatbot-api/__snapshots__/chatbot-api-construct.test.ts.snap
@@ -5477,7 +5477,7 @@ schema {
         },
         "EnableIAMDatabaseAuthentication": true,
         "Engine": "aurora-postgresql",
-        "EngineVersion": "15.7",
+        "EngineVersion": "15.10",
         "MasterUserPassword": {
           "Fn::Join": [
             "",


### PR DESCRIPTION
## Description

Updates Aurora PostgreSQL engine version to 15.10 (LTS) for improved stability and extended support. 
Fixes `Cannot find version 15.7 for aurora-postgresql ` error during deployment

## Motivation

- Version 15.10 is an LTS release with support until February 2028
- Previous version 15.7 no longer supported
- Provides longer maintenance window for production deployments

## Changes

- Updated `AuroraPostgresEngineVersion.VER_15_7 to `VER_15_10` in aurora-pgvector construct
- Updated test snapshots to match new engine version

## Testing

- [x] Existing unit tests pass
- [x] CDK synth completes successfully
- [x] Deployment tested in target environment

## References

- [Aurora PostgreSQL Release Calendar](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraPostgreSQLReleaseNotes/aurorapostgresql-release-calendar.html)
