### PR TITLE
fix: bedrock agent invocation & add documentation

### DIFF
--- a/cli/magic-config.ts
+++ b/cli/magic-config.ts
@@ -617,7 +617,7 @@ function getTypedEnvVar<T>(
               ),
               agentAliasId: getTypedEnvVar<string>(
                 "BEDROCK_AGENT_ALIAS_ID",
-                "",
+                "TSTALIASID",
                 options.envPrefix
               ),
             };
@@ -919,7 +919,8 @@ async function processCreateOptions(options: any): Promise<void> {
     {
       type: "input",
       name: "bedrockAgentId",
-      message: "Amazon Bedrock Agent ID",
+      message:
+        "Amazon Bedrock Agent ID (leave empty to fetch all agents from account)",
       validate(v: string) {
         return (this as any).skipped || v.length > 0;
       },
@@ -941,7 +942,8 @@ async function processCreateOptions(options: any): Promise<void> {
     {
       type: "input",
       name: "bedrockAgentAliasId",
-      message: "Amazon Bedrock Agent Alias ID",
+      message:
+        "Amazon Bedrock Agent Alias ID (defaults to draft alias TSTALIASID)",
       skip() {
         return !(this as any).state.answers.bedrockAgentEnable;
       },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -56,6 +56,7 @@ export default defineConfig({
           { text: 'AgentCore Integration', link: '/documentation/agentcore' },
           { text: 'Applications', link: '/documentation/applications' },
           { text: 'AppSync', link: '/documentation/appsync' },
+          { text: 'Bedrock Agents', link: '/documentation/bedrock-agents' },
           { text: 'CloudFront Geo Restriction', link: '/documentation/cf-geo-restriction' },
           {
             text: 'Cognito Federation', items: [

--- a/docs/documentation/bedrock-agents.md
+++ b/docs/documentation/bedrock-agents.md
@@ -1,0 +1,126 @@
+# Amazon Bedrock Agents Integration
+
+Amazon Bedrock Agents are fully managed agents that can complete tasks based on your organization's data and user input. Agents orchestrate interactions between foundation models, data sources, software applications, and user conversations. This integration allows you to leverage pre-built Bedrock Agents within the GenAI Chatbot, enabling sophisticated task automation and multi-step reasoning capabilities.
+
+::: tip Note
+Bedrock Agents integration is different from the [AgentCore](./agentcore.md) feature. Bedrock Agents are pre-configured agents managed through Amazon Bedrock, while AgentCore allows you to deploy custom agent runtimes.
+:::
+
+## Prerequisites
+
+1. **Create and deploy an Amazon Bedrock Agent** in your AWS account through the [Amazon Bedrock console](https://console.aws.amazon.com/bedrock/)
+2. **Note your Agent ID and Alias ID** - you'll need these during configuration
+3. **IAM Permissions** - The CDK deployment automatically configures the required permissions (`bedrock:InvokeAgent` and `bedrock:ListAgents`)
+
+## Configuration
+
+### Using Magic Config CLI
+
+The easiest way to configure Bedrock Agents is through the interactive Magic Config CLI:
+
+```bash
+npm run config
+```
+
+When prompted:
+- **Amazon Bedrock Agent ID**: Enter your agent ID, or leave empty to fetch all available agents from your account
+- **Amazon Bedrock Agent Alias ID**: Enter your alias ID, or leave empty to use the draft alias (`TSTALIASID`)
+
+The CLI will generate the appropriate configuration in your `bin/config.json` file.
+
+### Manual Configuration
+
+You can also manually configure Bedrock Agents by setting environment variables in your `bin/config.json`:
+
+```json
+{
+  "bedrockAgentEnable": true,
+  "bedrockAgentId": "YOUR_AGENT_ID",
+  "bedrockAgentAliasId": "YOUR_ALIAS_ID"
+}
+```
+
+**Configuration Options:**
+
+- `bedrockAgentEnable`: Set to `true` to enable Bedrock Agents integration
+- `bedrockAgentId`: Your Bedrock Agent ID (e.g., `ABCDEFGHIJ`)
+- `bedrockAgentAliasId`: Your Agent Alias ID (defaults to `TSTALIASID` for draft agents if not specified)
+
+::: info Draft Alias
+The special alias `TSTALIASID` is AWS-managed and used for testing draft versions of your agent. Learn more in the [AWS Bedrock Agent Testing Documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-test.html#test-your-agent).
+:::
+
+## Using Bedrock Agents
+
+![Bedrock Agents Demo](assets/bedrock-agents-demo.gif)
+
+### Agent Discovery
+
+The chatbot automatically discovers available Bedrock Agents in your account:
+
+- Agents are listed using the `list_agents()` function
+- Agent information includes name, status, available aliases, and versions
+- Only users with appropriate IAM permissions can access agent listings
+
+### Agent Selection
+
+In the chat interface:
+
+- Bedrock Agents appear in the model selection dropdown
+- Agents are identified by their agent name and ID
+- Select an agent just like you would select a foundation model
+- The system automatically uses the configured alias ID for invocation
+
+### Conversation Flow
+
+When you interact with a Bedrock Agent:
+
+1. **User Input**: You send a message through the chat interface
+2. **Agent Invocation**: The system invokes your Bedrock Agent with the message
+3. **Agent Processing**: The agent orchestrates actions, calls tools, and accesses data sources
+4. **Response**: The agent's response is streamed back to the chat interface
+5. **Session Management**: Conversation history is maintained for context continuity
+
+**Key Features:**
+
+- **Streaming Responses**: Agent responses stream in real-time for better user experience
+- **Session Continuity**: Each conversation maintains its own session state
+- **Trace Support**: Enable trace logging to debug agent behavior (configurable)
+- **Error Handling**: Graceful error recovery with informative messages
+
+## Troubleshooting
+
+### Agent Not Available
+
+- Verify your agent is created and in `PREPARED` or `VERSIONED` status in Bedrock
+- Confirm the agent ID matches exactly (case-sensitive)
+- Check IAM permissions for `bedrock:InvokeAgent` and `bedrock:ListAgents`
+- Ensure the agent is in the same region as your deployment
+
+### Invocation Errors
+
+- **Alias Not Found**: Verify the alias ID exists for your agent
+- **Session Errors**: Check CloudWatch logs for session management issues
+- **Timeout**: Increase the timeout value if your agent requires more processing time
+- **Permission Denied**: Confirm the Lambda execution role has necessary Bedrock permissions
+
+### Performance Considerations
+
+- Agents may take longer than direct model calls due to orchestration complexity
+- Monitor CloudWatch metrics for agent invocation times
+- Consider using versioned aliases for production workloads instead of draft
+- Session state is maintained server-side by Bedrock for optimal performance
+
+## Best Practices
+
+1. **Use Versioned Aliases**: Create versioned aliases for production deployments instead of using the draft alias
+2. **Enable Tracing**: Keep trace logging enabled during development for easier debugging
+3. **Monitor Costs**: Bedrock Agents incur charges based on invocations and processing time
+4. **Test Thoroughly**: Use the draft alias (`TSTALIASID`) for testing before deploying to production
+
+## Additional Resources
+
+- [Amazon Bedrock Agents Documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/agents.html)
+- [Creating Bedrock Agents](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-create.html)
+- [Agent Action Groups](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-action-create.html)
+- [Testing Bedrock Agents](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-test.html)

--- a/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/base.py
+++ b/lib/model-interfaces/langchain/functions/request-handler/adapters/bedrock/base.py
@@ -54,8 +54,8 @@ class BedrockChatAdapter(ModelAdapter):
         # Pattern matches any regional prefix (us., global., eu., etc.)
         single_param_model_patterns = [
             "anthropic.claude-sonnet-4",  # Claude Sonnet 4.x (any region)
-            "anthropic.claude-opus-4",    # Claude Opus 4.x (any region)
-            "anthropic.claude-haiku-4",   # Claude Haiku 4.x (any region)
+            "anthropic.claude-opus-4",  # Claude Opus 4.x (any region)
+            "anthropic.claude-haiku-4",  # Claude Haiku 4.x (any region)
         ]
 
         model_lower = self.model_id.lower()

--- a/lib/shared/layers/python-sdk/python/genai_core/model_providers/direct/provider.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/model_providers/direct/provider.py
@@ -218,8 +218,7 @@ def _list_bedrock_cris_models():
             if base_model_id in models_by_id:
                 result.append(
                     _create_bedrock_model_profile(
-                        models_by_id[base_model_id],
-                        profile_id
+                        models_by_id[base_model_id], profile_id
                     )
                 )
 

--- a/tests/shared/layers/python-sdk/genai_core/bedrock_agent/test_bedrok_agent_client.py
+++ b/tests/shared/layers/python-sdk/genai_core/bedrock_agent/test_bedrok_agent_client.py
@@ -249,7 +249,7 @@ class TestBedrockClients:
         assert result == {
             "agentId": "test-agent-id",
             "agentVersion": "DRAFT",
-            "agentAliasId": None,
+            "agentAliasId": "TSTALIASID",
         }
 
     def test_get_agent_config_no_agent_id(self):


### PR DESCRIPTION
## Fix Bedrock Agent Invocation & Add Documentation

### Summary
This MR fixes the Bedrock Agent invocation logic by properly handling the agent alias ID and simplifying the invocation flow. It also improves the configuration experience with better defaults and user guidance, and adds comprehensive documentation for the Bedrock Agents feature.

### Changes

#### Bedrock Agent Client
- **Fixed agent invocation logic**
  - Removed conditional branching that incorrectly used `agentVersion` as `agentAliasId`
  - Now always uses the proper `agentAliasId` parameter
  - Added default fallback to draft alias `TSTALIASID` when not specified
  - Added informative logging for default values

- **Improved configuration handling**
  - Added explicit checks and logging for missing environment variables
  - Defaults to `DRAFT` version when `BEDROCK_AGENT_VERSION` not set
  - Defaults to `TSTALIASID` (draft alias) when `BEDROCK_AGENT_ALIAS_ID` not set
  - Added reference to AWS documentation for draft alias usage

#### Magic Config CLI
- **Enhanced user experience**
  - Updated prompt messages to clarify optional fields and defaults
  - Agent ID prompt now indicates it can be left empty to fetch all agents
  - Agent Alias ID prompt now shows it defaults to draft alias `TSTALIASID`
  - Set default value for `agentAliasId` to `TSTALIASID` in environment variable handling

#### Documentation
- **New Bedrock Agents documentation**
  - Comprehensive guide covering prerequisites, configuration, and usage
  - Clear distinction from AgentCore feature
  - Configuration examples for both Magic Config CLI and manual setup
  - Troubleshooting section with common issues and solutions
  - Best practices for production deployments
  - Added demo GIF showing agent selection in UI

- **Updated VitePress config** (`docs/.vitepress/config.mts`)
  - Added Bedrock Agents to documentation navigation

### Code Quality
- **Formatting improvements**
  - Fixed whitespace alignment in Bedrock adapter model patterns
  - Cleaned up line formatting in model provider code

### Tests
- **Updated test expectations** (`tests/shared/layers/python-sdk/genai_core/bedrock_agent/test_bedrok_agent_client.py`)
  - Fixed `test_get_agent_config_defaults` to expect `TSTALIASID` as default instead of `None`
  - All 44 tests passing

## Testing
- Manual testing with Bedrock Agent invocations
- Verified default alias behavior with draft agents
- Confirmed improved CLI prompts and configuration flow
- All unit tests passing

## Notes
- The draft alias `TSTALIASID` is a special AWS-managed alias for testing agents
- See [AWS Bedrock Agent Testing Documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-test.html#test-your-agent)
- This fix resolves issues where agents couldn't be invoked due to incorrect alias ID handling


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
