### PR TITLE
feat: allow AgentCore agent selection in Applications

### DIFF
--- a/integtests/chatbot-api/application_test.py
+++ b/integtests/chatbot-api/application_test.py
@@ -134,3 +134,81 @@ def test_update_application(client: AppSyncClient):
 def test_delete_application(client: AppSyncClient):
     result = client.delete_application(pytest.application.get("id"))
     assert result == True
+
+
+# --- Agent application integration test ---
+
+AGENT_RUNTIME_ARN = "arn:aws:bedrock-agentcore:eu-central-1:481665129290:runtime/rapidRed_Agent-0S40yv5Brf"
+
+
+def test_create_agent_application(client: AppSyncClient):
+    pytest.agent_application = client.create_application(
+        input={
+            "name": "INTEG_TEST_AGENT_APP",
+            "agentRuntimeArn": AGENT_RUNTIME_ARN,
+            "roles": ["user"],
+            "allowImageInput": False,
+            "allowVideoInput": False,
+            "allowDocumentInput": False,
+            "enableGuardrails": False,
+            "streaming": True,
+            "maxTokens": 512,
+            "temperature": 0.6,
+            "topP": 0.9,
+        }
+    )
+
+    assert pytest.agent_application.get("id") is not None
+    assert pytest.agent_application.get("name") == "INTEG_TEST_AGENT_APP"
+    assert pytest.agent_application.get("agentRuntimeArn") == AGENT_RUNTIME_ARN
+
+
+def test_get_agent_application(client: AppSyncClient):
+    application = client.get_application(pytest.agent_application.get("id"))
+    assert application.get("agentRuntimeArn") == AGENT_RUNTIME_ARN
+    assert application.get("name") == "INTEG_TEST_AGENT_APP"
+
+
+def test_query_agent_application(client: AppSyncClient):
+    """Test that an agent-based application routes messages to the agent
+    and creates a session with both user and AI messages."""
+    session_id = str(uuid.uuid4())
+    request = {
+        "action": "run",
+        "modelInterface": "agent",
+        "applicationId": pytest.agent_application.get("id"),
+        "data": {
+            "mode": "chain",
+            "text": "What is 2 + 2?",
+            "images": [],
+            "documents": [],
+            "videos": [],
+            "sessionId": session_id,
+        },
+    }
+
+    client.send_query(json.dumps(request))
+
+    found = False
+    retries = 0
+    while not found and retries < 20:
+        time.sleep(5)
+        retries += 1
+        session = client.get_session(session_id)
+
+        if (
+            session is not None
+            and len(session.get("history", [])) >= 2
+            and session.get("history")[0].get("type") == "human"
+            and session.get("history")[1].get("type") == "ai"
+            and len(session.get("history")[1].get("content", "")) > 0
+        ):
+            found = True
+            break
+    client.delete_session(session_id)
+    assert found is True, f"Agent response empty or missing. Session: {session}"
+
+
+def test_delete_agent_application(client: AppSyncClient):
+    result = client.delete_application(pytest.agent_application.get("id"))
+    assert result is True

--- a/integtests/chatbot-api/application_test.py
+++ b/integtests/chatbot-api/application_test.py
@@ -138,7 +138,7 @@ def test_delete_application(client: AppSyncClient):
 
 # --- Agent application integration test ---
 
-AGENT_RUNTIME_ARN = "arn:aws:bedrock-agentcore:eu-central-1:481665129290:runtime/rapidRed_Agent-0S40yv5Brf"
+AGENT_RUNTIME_ARN = "arn:aws:bedrock-agentcore:eu-central-1:123456789012:runtime/test-Agent-0S40yv5Brf"
 
 
 def test_create_agent_application(client: AppSyncClient):

--- a/integtests/clients/appsync_client.py
+++ b/integtests/clients/appsync_client.py
@@ -397,6 +397,7 @@ class AppSyncClient:
                 self.schema.Mutation.createApplication.args(input=input).select(
                     self.schema.Application.id,
                     self.schema.Application.name,
+                    self.schema.Application.agentRuntimeArn,
                     self.schema.Application.workspace,
                     self.schema.Application.systemPrompt,
                     self.schema.Application.systemPromptRag,
@@ -423,6 +424,7 @@ class AppSyncClient:
                 self.schema.Mutation.updateApplication.args(input=input).select(
                     self.schema.Application.id,
                     self.schema.Application.name,
+                    self.schema.Application.agentRuntimeArn,
                     self.schema.Application.workspace,
                     self.schema.Application.systemPrompt,
                     self.schema.Application.systemPromptRag,
@@ -449,6 +451,7 @@ class AppSyncClient:
                 self.schema.Query.getApplication.args(id=id).select(
                     self.schema.Application.id,
                     self.schema.Application.name,
+                    self.schema.Application.agentRuntimeArn,
                     self.schema.Application.workspace,
                     self.schema.Application.systemPrompt,
                     self.schema.Application.systemPromptRag,

--- a/lib/chatbot-api/functions/api-handler/routes/applications.py
+++ b/lib/chatbot-api/functions/api-handler/routes/applications.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from typing import Optional
 from common.constant import (
     ID_FIELD_VALIDATION,
@@ -25,7 +25,7 @@ logger = Logger()
 permissions = UserPermissions(router)
 
 name_regex = r"^[\w\s+_-]+$"
-ARN_REGEX = r"^[A-Za-z0-9-_.:/]+$"
+ARN_REGEX = r"^arn:aws(-[a-z]+)*:bedrock-agentcore:[a-z0-9-]+:\d{12}:runtime/[\w-]+$"
 
 
 class CreateApplicationRequest(BaseModel):
@@ -36,6 +36,7 @@ class CreateApplicationRequest(BaseModel):
     agentRuntimeArn: Optional[str] = Field(
         None, max_length=500, pattern=ARN_REGEX
     )
+
     workspace: str = Field(None, max_length=512, pattern=SAFE_STR_REGEX)
     systemPrompt: str = Field(None, max_length=256, pattern=SAFE_PROMPT_STR_REGEX)
     systemPromptRag: str = Field(None, max_length=256, pattern=SAFE_PROMPT_STR_REGEX)
@@ -51,6 +52,14 @@ class CreateApplicationRequest(BaseModel):
     maxTokens: int = Field(ge=1, le=8192)
     temperature: Decimal = Field(ge=0, le=1)
     topP: Decimal = Field(ge=0, le=1)
+
+    @model_validator(mode="after")
+    def check_model_or_agent(self):
+        if self.model and self.agentRuntimeArn:
+            raise ValueError("Specify either model or agentRuntimeArn, not both")
+        if not self.model and not self.agentRuntimeArn:
+            raise ValueError("Either model or agentRuntimeArn must be provided")
+        return self
 
 
 class UpdateApplicationRequest(BaseModel):
@@ -77,6 +86,14 @@ class UpdateApplicationRequest(BaseModel):
     maxTokens: int = Field(ge=1, le=8192)
     temperature: Decimal = Field(ge=0, le=1)
     topP: Decimal = Field(ge=0, le=1)
+
+    @model_validator(mode="after")
+    def check_model_or_agent(self):
+        if self.model and self.agentRuntimeArn:
+            raise ValueError("Specify either model or agentRuntimeArn, not both")
+        if not self.model and not self.agentRuntimeArn:
+            raise ValueError("Either model or agentRuntimeArn must be provided")
+        return self
 
 
 @router.resolver(field_name="listApplications")

--- a/lib/chatbot-api/functions/api-handler/routes/applications.py
+++ b/lib/chatbot-api/functions/api-handler/routes/applications.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel, Field
+from typing import Optional
 from common.constant import (
     ID_FIELD_VALIDATION,
     SAFE_PROMPT_STR_REGEX,
@@ -24,11 +25,17 @@ logger = Logger()
 permissions = UserPermissions(router)
 
 name_regex = r"^[\w\s+_-]+$"
+ARN_REGEX = r"^[A-Za-z0-9-_.:/]+$"
 
 
 class CreateApplicationRequest(BaseModel):
     name: str = Field(min_length=1, max_length=100, pattern=name_regex)
-    model: str = SAFE_SHORT_STR_VALIDATION
+    model: Optional[str] = Field(
+        None, min_length=1, max_length=100, pattern=SAFE_STR_REGEX
+    )
+    agentRuntimeArn: Optional[str] = Field(
+        None, max_length=500, pattern=ARN_REGEX
+    )
     workspace: str = Field(None, max_length=512, pattern=SAFE_STR_REGEX)
     systemPrompt: str = Field(None, max_length=256, pattern=SAFE_PROMPT_STR_REGEX)
     systemPromptRag: str = Field(None, max_length=256, pattern=SAFE_PROMPT_STR_REGEX)
@@ -49,7 +56,12 @@ class CreateApplicationRequest(BaseModel):
 class UpdateApplicationRequest(BaseModel):
     id: str = ID_FIELD_VALIDATION
     name: str = Field(min_length=1, max_length=100, pattern=name_regex)
-    model: str = SAFE_SHORT_STR_VALIDATION
+    model: Optional[str] = Field(
+        None, min_length=1, max_length=100, pattern=SAFE_STR_REGEX
+    )
+    agentRuntimeArn: Optional[str] = Field(
+        None, max_length=500, pattern=ARN_REGEX
+    )
     workspace: str = Field(None, max_length=512, pattern=SAFE_STR_REGEX)
     systemPrompt: str = Field(None, max_length=256, pattern=SAFE_PROMPT_STR_REGEX)
     systemPromptRag: str = Field(None, max_length=256, pattern=SAFE_PROMPT_STR_REGEX)
@@ -96,6 +108,7 @@ def list_applications():
                 "id": app.get("Id"),
                 "name": app.get("Name"),
                 "model": app.get("Model"),
+                "agentRuntimeArn": app.get("AgentRuntimeArn"),
                 "workspace": app.get("Workspace"),
                 "outputModalities": app.get("OutputModalities"),
                 "systemPrompt": app.get("SystemPrompt"),
@@ -150,6 +163,7 @@ def get_application(id: str):
             "id": app.get("Id"),
             "name": app.get("Name"),
             "model": app.get("Model"),
+            "agentRuntimeArn": app.get("AgentRuntimeArn"),
             "workspace": app.get("Workspace"),
             "outputModalities": app.get("OutputModalities"),
             "systemPrompt": app.get("SystemPrompt"),
@@ -224,12 +238,14 @@ def update_application(input: dict):
         request.maxTokens,
         request.temperature,
         request.topP,
+        agentRuntimeArn=request.agentRuntimeArn,
     )
 
     return {
         "id": application.get("Id"),
         "name": application.get("Name"),
         "model": application.get("Model"),
+        "agentRuntimeArn": application.get("AgentRuntimeArn"),
         "workspace": application.get("Workspace"),
         "systemPrompt": application.get("SystemPrompt"),
         "systemPromptRag": application.get("SystemPromptRag"),
@@ -265,12 +281,14 @@ def _create_application(request: CreateApplicationRequest):
         request.maxTokens,
         request.temperature,
         request.topP,
+        agentRuntimeArn=request.agentRuntimeArn,
     )
 
     return {
         "id": application.get("Id"),
         "name": application.get("Name"),
         "model": application.get("Model"),
+        "agentRuntimeArn": application.get("AgentRuntimeArn"),
         "workspace": application.get("Workspace"),
         "systemPrompt": application.get("SystemPrompt"),
         "systemPromptRag": application.get("SystemPromptRag"),

--- a/lib/chatbot-api/functions/resolvers/send-query-lambda-resolver/index.py
+++ b/lib/chatbot-api/functions/resolvers/send-query-lambda-resolver/index.py
@@ -20,7 +20,7 @@ TOPIC_ARN = os.environ.get("SNS_TOPIC_ARN", "")
 
 MAX_STR_INPUT_LENGTH = 1000000
 SAFE_STR_REGEX = r"^[A-Za-z0-9-_. ]*$"
-ARN_REGEX = r"^[A-Za-z0-9-_.:/ ]*$"  # Allow ARN format with colons and slashes
+ARN_REGEX = r"^arn:aws(-[a-z]+)*:bedrock-agentcore:[a-z0-9-]+:\d{12}:runtime/[\w-]+$"  # Bedrock AgentCore runtime ARN
 SAFE_SHORT_STR_VALIDATION = Field(min_length=0, max_length=500, pattern=SAFE_STR_REGEX)
 SAFE_SHORT_STR_VALIDATION_OPTIONAL = Field(
     min_length=0, max_length=500, pattern=SAFE_STR_REGEX, default=None

--- a/lib/chatbot-api/functions/resolvers/send-query-lambda-resolver/index.py
+++ b/lib/chatbot-api/functions/resolvers/send-query-lambda-resolver/index.py
@@ -93,46 +93,94 @@ def handler(event, context: LambdaContext):
         ):
             raise RuntimeError("User is not authorized to access this application")
         logger.info("Application item 2", applicationItem=application_item)
-        provider = application_item.get("Model").split("::")[0]
-        modelName = application_item.get("Model").split("::")[1]
-        workspace_value = application_item.get("Workspace")
         allow_images = application_item.get("AllowImageInput")
         allow_videos = application_item.get("AllowVideoInput")
         allow_documents = application_item.get("AllowDocumentInput")
-        workspaceId = workspace_value.split("::")[-1] if workspace_value else None
 
-        modelKwargs = {
-            "streaming": application_item.get("Streaming", False),
-            "maxTokens": int(application_item.get("MaxTokens", 512)),
-            "temperature": float(application_item.get("Temperature", 0.6)),
-            "topP": float(application_item.get("TopP", 0.9)),
-        }
-        system_prompts = {
-            "systemPrompt": application_item.get("SystemPrompt", ""),
-            "systemPromptRag": application_item.get("SystemPromptRag", ""),
-            "condenseSystemPrompt": application_item.get("CondenseSystemPrompt", ""),
-        }
-        message = {
-            "action": request["action"],
-            "modelInterface": request["modelInterface"],
-            "direction": "IN",
-            "timestamp": str(int(round(datetime.now().timestamp()))),
-            "userId": event["identity"]["sub"],
-            "userGroups": user_roles,
-            "systemPrompts": system_prompts,
-            "data": {
-                "mode": request["data"]["mode"] or "chain",
+        agent_runtime_arn = application_item.get("AgentRuntimeArn")
+
+        if agent_runtime_arn:
+            # Agent-based application
+            model_value = application_item.get("Model")
+            modelKwargs = {
+                "streaming": application_item.get("Streaming", False),
+                "maxTokens": int(application_item.get("MaxTokens", 512)),
+                "temperature": float(application_item.get("Temperature", 0.6)),
+                "topP": float(application_item.get("TopP", 0.9)),
+            }
+            data = {
+                "mode": "chain",
                 "text": request["data"]["text"],
                 "images": request["data"]["images"] if allow_images else [],
                 "videos": request["data"]["videos"] if allow_videos else [],
-                "documents": request["data"]["documents"] if allow_documents else [],
-                "modelName": modelName,
-                "provider": provider,
+                "documents": (
+                    request["data"]["documents"] if allow_documents else []
+                ),
+                "agentRuntimeArn": agent_runtime_arn,
                 "sessionId": request["data"]["sessionId"],
-                "workspaceId": workspaceId,
                 "modelKwargs": modelKwargs,
-            },
-        }
+            }
+            if model_value:
+                data["modelName"] = model_value.split("::")[1]
+                data["provider"] = model_value.split("::")[0]
+            message = {
+                "action": request["action"],
+                "modelInterface": "agent",
+                "direction": "IN",
+                "timestamp": str(int(round(datetime.now().timestamp()))),
+                "userId": event["identity"]["sub"],
+                "userGroups": user_roles,
+                "data": data,
+            }
+        else:
+            # Model-based application
+            provider = application_item.get("Model").split("::")[0]
+            modelName = application_item.get("Model").split("::")[1]
+            workspace_value = application_item.get("Workspace")
+            workspaceId = (
+                workspace_value.split("::")[-1] if workspace_value else None
+            )
+
+            modelKwargs = {
+                "streaming": application_item.get("Streaming", False),
+                "maxTokens": int(application_item.get("MaxTokens", 512)),
+                "temperature": float(application_item.get("Temperature", 0.6)),
+                "topP": float(application_item.get("TopP", 0.9)),
+            }
+            system_prompts = {
+                "systemPrompt": application_item.get("SystemPrompt", ""),
+                "systemPromptRag": application_item.get("SystemPromptRag", ""),
+                "condenseSystemPrompt": application_item.get(
+                    "CondenseSystemPrompt", ""
+                ),
+            }
+            message = {
+                "action": request["action"],
+                "modelInterface": "langchain",
+                "direction": "IN",
+                "timestamp": str(int(round(datetime.now().timestamp()))),
+                "userId": event["identity"]["sub"],
+                "userGroups": user_roles,
+                "systemPrompts": system_prompts,
+                "data": {
+                    "mode": request["data"]["mode"] or "chain",
+                    "text": request["data"]["text"],
+                    "images": (
+                        request["data"]["images"] if allow_images else []
+                    ),
+                    "videos": (
+                        request["data"]["videos"] if allow_videos else []
+                    ),
+                    "documents": (
+                        request["data"]["documents"] if allow_documents else []
+                    ),
+                    "modelName": modelName,
+                    "provider": provider,
+                    "sessionId": request["data"]["sessionId"],
+                    "workspaceId": workspaceId,
+                    "modelKwargs": modelKwargs,
+                },
+            }
     else:
         if not ("admin" in user_roles or "workspace_manager" in user_roles):
             raise RuntimeError("User is not authorized to access this application")

--- a/lib/chatbot-api/schema/schema.graphql
+++ b/lib/chatbot-api/schema/schema.graphql
@@ -239,7 +239,8 @@ input SemanticSearchInput {
 input ManageApplicationInput {
   id: String
   name: String!
-  model: String!
+  model: String
+  agentRuntimeArn: String
   workspace: String
   systemPrompt: String
   systemPromptRag: String
@@ -376,6 +377,7 @@ type Application @aws_cognito_user_pools {
   id: String!
   name: String!
   model: String
+  agentRuntimeArn: String
   workspace: String
   systemPrompt: String
   systemPromptRag: String

--- a/lib/shared/layers/python-sdk/python/genai_core/applications.py
+++ b/lib/shared/layers/python-sdk/python/genai_core/applications.py
@@ -1,6 +1,8 @@
 from decimal import Decimal
 import os
+import re
 import uuid
+from typing import Optional
 from aws_lambda_powertools import Logger
 import boto3
 from datetime import datetime
@@ -96,13 +98,19 @@ def create_application(
     maxTokens: int,
     temperature: Decimal,
     topP: Decimal,
+    agentRuntimeArn: Optional[str] = None,
 ):
     application_id = str(uuid.uuid4())
     timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
-    validate_request(workspace=workspace, roles=roles, model=model)
+    validate_request(
+        workspace=workspace, roles=roles, model=model,
+        agentRuntimeArn=agentRuntimeArn,
+    )
 
-    output_modalities = genai_core.models.get_model_modalities(model)
+    output_modalities = (
+        genai_core.models.get_model_modalities(model) if model else ["text"]
+    )
     item = {
         "Id": application_id,
         "Name": name,
@@ -124,6 +132,9 @@ def create_application(
         "CreateTime": timestamp,
         "UpdateTime": timestamp,
     }
+
+    if agentRuntimeArn:
+        item["AgentRuntimeArn"] = agentRuntimeArn
 
     ddb_response = table.put_item(Item=item)
 
@@ -152,14 +163,20 @@ def update_application(
     maxTokens: int,
     temperature: Decimal,
     topP: Decimal,
+    agentRuntimeArn: Optional[str] = None,
 ):
     response = table.get_item(Key={"Id": id})
     if response.get("Item") is None:
         raise genai_core.types.CommonError("Unknown application")
 
     timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-    validate_request(workspace=workspace, roles=roles, model=model)
-    output_modalities = genai_core.models.get_model_modalities(model)
+    validate_request(
+        workspace=workspace, roles=roles, model=model,
+        agentRuntimeArn=agentRuntimeArn,
+    )
+    output_modalities = (
+        genai_core.models.get_model_modalities(model) if model else ["text"]
+    )
     item = {
         "Id": id,
         "Name": name,
@@ -168,7 +185,7 @@ def update_application(
         "Workspace": workspace,
         "SystemPrompt": systemPrompt,
         "SystemPromptRag": systemPromptRag,
-        "ConsiseSystemPrompt": condenseSystemPrompt,
+        "CondenseSystemPrompt": condenseSystemPrompt,
         "Roles": roles,
         "AllowImageInput": allowImageInput,
         "AllowVideoInput": allowVideoInput,
@@ -181,6 +198,9 @@ def update_application(
         "CreateTime": response.get("Item").get("CreateTime"),
         "UpdateTime": timestamp,
     }
+
+    if agentRuntimeArn:
+        item["AgentRuntimeArn"] = agentRuntimeArn
 
     ddb_response = table.put_item(Item=item)
 
@@ -207,19 +227,33 @@ def delete_application(id):
     return True
 
 
-def validate_request(workspace, roles, model):
-    all_models = genai_core.models.list_models()
-    model_found = False
-    model_split = model.split("::")
-    if len(model_split) != 2:
-        raise genai_core.types.CommonError("Model not found")
-    for m in all_models:
-        if m.get("provider") == model_split[0] and m.get("name") == model_split[1]:
-            model_found = True
-            break
+def validate_request(workspace, roles, model, agentRuntimeArn=None):
+    if agentRuntimeArn:
+        arn_pattern = (
+            r"^arn:aws:bedrock-agentcore:[a-z0-9-]+:\d{12}:runtime/[a-zA-Z0-9_-]+$"
+        )
+        if not re.match(arn_pattern, agentRuntimeArn):
+            raise genai_core.types.CommonError("Invalid agent runtime ARN format")
+    elif model:
+        all_models = genai_core.models.list_models()
+        model_found = False
+        model_split = model.split("::")
+        if len(model_split) != 2:
+            raise genai_core.types.CommonError("Model not found")
+        for m in all_models:
+            if (
+                m.get("provider") == model_split[0]
+                and m.get("name") == model_split[1]
+            ):
+                model_found = True
+                break
 
-    if model_found == False:
-        raise genai_core.types.CommonError("Model not found")
+        if model_found is False:
+            raise genai_core.types.CommonError("Model not found")
+    else:
+        raise genai_core.types.CommonError(
+            "Either model or agentRuntimeArn must be provided"
+        )
 
     all_roles = genai_core.roles.list_roles()
     all_roles_names = list(map(lambda o: o.get("name"), all_roles))

--- a/lib/user-interface/react-app/src/common/api-client/applications-client.ts
+++ b/lib/user-interface/react-app/src/common/api-client/applications-client.ts
@@ -50,7 +50,8 @@ export class ApplicationsClient {
 
   async createApplication(params: {
     name: string;
-    model: string;
+    model?: string | null;
+    agentRuntimeArn?: string | null;
     workspaceId?: string | null;
     systemPrompt?: string | null;
     systemPromptRag?: string | null;
@@ -78,7 +79,8 @@ export class ApplicationsClient {
   async updateApplication(params: {
     id: string;
     name: string;
-    model: string;
+    model?: string | null;
+    agentRuntimeArn?: string | null;
     workspaceId?: string | null;
     systemPrompt?: string | null;
     systemPromptRag?: string | null;

--- a/lib/user-interface/react-app/src/common/types.ts
+++ b/lib/user-interface/react-app/src/common/types.ts
@@ -108,6 +108,7 @@ export interface ApplicationManageInput {
   condenseSystemPrompt: string;
   selectedRoles: readonly SelectProps.Option[];
   selectedModel: SelectProps.Option | null;
+  selectedAgent: SelectProps.Option | null;
   selectedWorkspace: SelectProps.Option | null;
   allowImageInput: boolean;
   allowDocumentInput: boolean;

--- a/lib/user-interface/react-app/src/components/chatbot/chat-input-panel.tsx
+++ b/lib/user-interface/react-app/src/components/chatbot/chat-input-panel.tsx
@@ -538,7 +538,7 @@ export default function ChatInputPanel(props: ChatInputPanelProps) {
     const request: ChatBotRunRequest = props.applicationId
       ? {
           action: ChatBotAction.Run,
-          modelInterface: "langchain", // We allow only langchain models in app creation
+          modelInterface: application?.agentRuntimeArn ? "agent" : "langchain",
           data: {
             mode: getChatBotMode(outputModality),
             text: value,

--- a/lib/user-interface/react-app/src/pages/admin/manage-application/application-form.tsx
+++ b/lib/user-interface/react-app/src/pages/admin/manage-application/application-form.tsx
@@ -122,14 +122,15 @@ export default function ApplicationForm(props: ApplicationFormProps) {
     }
   }, [selectedModel, models]);
 
+  const { data: propsData, onChange: propsOnChange } = props;
   useEffect(() => {
     if (!appContext?.config) return;
     const fetchApplication = async () => {
-      if (props.data && props.data.id && initialLoad) {
+      if (propsData && propsData.id && initialLoad) {
         const apiClient = new ApiClient(appContext);
         try {
           const result = await apiClient.applications.getApplication(
-            props.data.id
+            propsData.id
           );
           if (!result.data?.getApplication?.model) {
             if (!result.data?.getApplication?.agentRuntimeArn) {
@@ -150,7 +151,7 @@ export default function ApplicationForm(props: ApplicationFormProps) {
               value: agentArn,
             };
             setSelectedAgent(agentOption);
-            props.onChange({ selectedAgent: agentOption });
+            propsOnChange({ selectedAgent: agentOption });
           }
 
           if (result.data?.getApplication?.workspace) {
@@ -169,7 +170,7 @@ export default function ApplicationForm(props: ApplicationFormProps) {
     };
 
     fetchApplication();
-  }, [appContext, props.data, initialLoad]);
+  }, [appContext, propsData, propsOnChange, initialLoad]);
 
   const langchainModels = models.filter((m) => m.interface === "langchain");
   const modelsOptions = OptionsHelper.getSelectOptionGroups(langchainModels);

--- a/lib/user-interface/react-app/src/pages/admin/manage-application/application-form.tsx
+++ b/lib/user-interface/react-app/src/pages/admin/manage-application/application-form.tsx
@@ -17,7 +17,7 @@ import {
 import { ApplicationManageInput, LoadingStatus } from "../../../common/types";
 import { useContext, useEffect, useState } from "react";
 import { Utils } from "../../../common/utils";
-import { Model, Role, Workspace } from "../../../API";
+import { Agent, Model, Role, Workspace } from "../../../API";
 import { AppContext } from "../../../common/app-context";
 import { ApiClient } from "../../../common/api-client/api-client";
 import { getSelectedModelMetadata } from "../../../components/chatbot/utils";
@@ -64,6 +64,10 @@ export default function ApplicationForm(props: ApplicationFormProps) {
     useState<Model | null>();
   const [rolesStatus, setRolesStatus] = useState<LoadingStatus>("loading");
   const [roles, setRoles] = useState<Role[]>([]);
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [agentsStatus, setAgentsStatus] = useState<LoadingStatus>("loading");
+  const [selectedAgent, setSelectedAgent] =
+    useState<SelectProps.Option | null>(null);
   const [initialLoad, setInitialLoad] = useState(true);
   const [outputModality, setOutputModality] = useState<ChabotOutputModality>();
 
@@ -73,13 +77,13 @@ export default function ApplicationForm(props: ApplicationFormProps) {
     (async () => {
       const apiClient = new ApiClient(appContext);
       try {
-        const [modelsResult, workspacesResult, rolesResult] = await Promise.all(
-          [
+        const [modelsResult, workspacesResult, rolesResult, agentsResult] =
+          await Promise.all([
             apiClient.models.getModels(),
             apiClient.workspaces.getWorkspaces(),
             apiClient.roles.getRoles(),
-          ]
-        );
+            apiClient.agents.getAgents(),
+          ]);
 
         const models = modelsResult.data ? modelsResult.data.listModels : [];
         setModels(models);
@@ -94,6 +98,10 @@ export default function ApplicationForm(props: ApplicationFormProps) {
         const roles = rolesResult.data ? rolesResult.data.listRoles : [];
         setRoles(roles);
         setRolesStatus("finished");
+
+        const agentsList = agentsResult.data?.listAgents || [];
+        setAgents(agentsList);
+        setAgentsStatus("finished");
 
         setLoading(false);
       } catch (error) {
@@ -124,13 +132,25 @@ export default function ApplicationForm(props: ApplicationFormProps) {
             props.data.id
           );
           if (!result.data?.getApplication?.model) {
-            setModelsStatus("error");
+            if (!result.data?.getApplication?.agentRuntimeArn) {
+              setModelsStatus("error");
+            }
           } else {
             const selectedModelOption = {
               label: result.data?.getApplication?.model.split("::")[1],
               value: result.data?.getApplication?.model,
             };
             setSelectedModel(selectedModelOption);
+          }
+
+          if (result.data?.getApplication?.agentRuntimeArn) {
+            const agentArn = result.data.getApplication.agentRuntimeArn;
+            const agentOption = {
+              label: agentArn.split("/").pop() ?? agentArn,
+              value: agentArn,
+            };
+            setSelectedAgent(agentOption);
+            props.onChange({ selectedAgent: agentOption });
           }
 
           if (result.data?.getApplication?.workspace) {
@@ -158,6 +178,16 @@ export default function ApplicationForm(props: ApplicationFormProps) {
     ...OptionsHelper.getSelectOptions(workspaces ?? []),
   ];
   const rolesOptions = OptionsHelper.getSelectOptions(roles);
+  const agentOptions: SelectProps.Option[] = [
+    { label: "No agent", value: "", iconName: "close" },
+    ...agents
+      .filter((a) => a.status === "READY")
+      .map((a) => ({
+        label: a.agentRuntimeName,
+        value: a.agentRuntimeArn,
+        description: a.description ?? undefined,
+      })),
+  ];
   // When not using a bedrock models, the guardrails (Bedrock ApplyGuardrail API) is called after the full response
   // This prevents streaming capabilities.
   // For bedrock models, streaming is possible but delayed
@@ -205,10 +235,35 @@ export default function ApplicationForm(props: ApplicationFormProps) {
               />
             </FormField>
 
+            <FormField
+              label="Agent"
+              description="Select an AgentCore agent. When set, the agent handles the conversation instead of a direct LLM model."
+              errorText={props.errors.selectedAgent}
+            >
+              <Select
+                disabled={props.submitting}
+                selectedAriaLabel="Selected"
+                placeholder="No agent (use model directly)"
+                statusType={agentsStatus}
+                loadingText="Loading agents..."
+                selectedOption={selectedAgent}
+                options={agentOptions}
+                onChange={({ detail: { selectedOption } }) => {
+                  const hasAgent = !!selectedOption?.value;
+                  setSelectedAgent(hasAgent ? selectedOption : null);
+                  props.onChange({
+                    selectedAgent: hasAgent ? selectedOption : null,
+                  });
+                }}
+              />
+            </FormField>
+
             {appContext?.config.rag_enabled && (
               <FormField label="Workspace" errorText={props.errors.workspace}>
                 <Select
-                  disabled={!selectedModelMetadata?.ragSupported}
+                  disabled={
+                    !selectedModelMetadata?.ragSupported
+                  }
                   loadingText="Loading workspaces (might take few seconds)..."
                   statusType={workspacesStatus}
                   placeholder="Select a workspace (RAG data source)"

--- a/lib/user-interface/react-app/src/pages/admin/manage-application/manage-application.tsx
+++ b/lib/user-interface/react-app/src/pages/admin/manage-application/manage-application.tsx
@@ -27,6 +27,7 @@ const customPromptRegex = /^[A-Za-z0-9-_., !?]*$/;
 const defaults: ApplicationManageInput = {
   name: "",
   selectedModel: null,
+  selectedAgent: null,
   selectedWorkspace: null,
   systemPrompt: "",
   systemPromptRag: "",
@@ -84,6 +85,7 @@ export default function ManageApplication() {
             selectedModel: OptionsHelper.getSelectOption(
               application.model ?? ""
             ),
+            selectedAgent: null,
             selectedWorkspace: OptionsHelper.getSelectOption(
               application.workspace || ""
             ),
@@ -119,8 +121,8 @@ export default function ManageApplication() {
           "Application name can only contain letters, numbers, underscores, whitespaces and dashes";
       }
 
-      if (!form.selectedModel) {
-        errors.model = "Model is required";
+      if (!form.selectedModel && !form.selectedAgent) {
+        errors.model = "Model or Agent is required";
       }
 
       if (!form.selectedRoles || form.selectedRoles.length === 0) {
@@ -161,7 +163,7 @@ export default function ManageApplication() {
     if (
       applicationId &&
       application &&
-      application.model &&
+      (application.model || application.agentRuntimeArn) &&
       application.roles &&
       application.roles.length > 0 &&
       application.allowImageInput !== undefined &&
@@ -171,7 +173,15 @@ export default function ManageApplication() {
       const initialValues = {
         id: applicationId,
         name: application.name,
-        selectedModel: OptionsHelper.getSelectOption(application.model),
+        selectedModel: application.model
+          ? OptionsHelper.getSelectOption(application.model)
+          : null,
+        selectedAgent: application.agentRuntimeArn
+          ? {
+              label: application.agentRuntimeArn.split("/").pop() ?? "",
+              value: application.agentRuntimeArn,
+            }
+          : null,
         selectedWorkspace: OptionsHelper.getSelectOption(
           application.workspace || ""
         ),
@@ -200,11 +210,16 @@ export default function ManageApplication() {
     setGlobalError(undefined);
     setSubmitting(true);
 
-    const selectedModel = OptionsHelper.parseValue(data.selectedModel?.value);
+    const selectedModel = data.selectedModel?.value
+      ? OptionsHelper.parseValue(data.selectedModel.value)
+      : null;
 
     const newApplicationObj = {
       name: data.name.trim(),
-      model: selectedModel.provider + "::" + selectedModel.name,
+      model: selectedModel
+        ? selectedModel.provider + "::" + selectedModel.name
+        : undefined,
+      agentRuntimeArn: data.selectedAgent?.value || undefined,
       workspace: data.selectedWorkspace?.value
         ? OptionsHelper.parseWorkspaceValue(data.selectedWorkspace)
         : "",
@@ -246,13 +261,18 @@ export default function ManageApplication() {
     setGlobalError(undefined);
     setSubmitting(true);
 
-    const selectedModel = OptionsHelper.parseValue(data.selectedModel?.value);
+    const selectedModel = data.selectedModel?.value
+      ? OptionsHelper.parseValue(data.selectedModel.value)
+      : null;
     if (!applicationId) return;
 
     const newApplicationObj = {
       id: applicationId || application?.id || "",
       name: data.name.trim(),
-      model: selectedModel.provider + "::" + selectedModel.name,
+      model: selectedModel
+        ? selectedModel.provider + "::" + selectedModel.name
+        : undefined,
+      agentRuntimeArn: data.selectedAgent?.value || undefined,
       workspace: data.selectedWorkspace?.value
         ? OptionsHelper.parseWorkspaceValue(data.selectedWorkspace)
         : "",

--- a/tests/chatbot-api/functions/api-handler/routes/applications_test.py
+++ b/tests/chatbot-api/functions/api-handler/routes/applications_test.py
@@ -50,6 +50,38 @@ create_application_input = {
     "maxTokens": 1024,
 }
 
+agent_application = {
+    "Id": "agent_app_id",
+    "Name": "agent app",
+    "AgentRuntimeArn": "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent",
+    "OutputModalities": ["text"],
+    "Roles": ["role1"],
+    "AllowImageInput": False,
+    "AllowVideoInput": False,
+    "AllowDocumentInput": False,
+    "EnableGuardrails": False,
+    "Streaming": False,
+    "Temperature": 0.7,
+    "TopP": 1.0,
+    "MaxTokens": 1024,
+    "CreateTime": now,
+    "UpdateTime": now,
+}
+
+create_agent_application_input = {
+    "name": "agent app",
+    "agentRuntimeArn": "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent",
+    "roles": ["role1"],
+    "allowImageInput": False,
+    "allowVideoInput": False,
+    "allowDocumentInput": False,
+    "enableGuardrails": False,
+    "streaming": False,
+    "temperature": 0.7,
+    "topP": 1.0,
+    "maxTokens": 1024,
+}
+
 
 def test_list_applications(mocker):
     mocker.patch(
@@ -186,11 +218,10 @@ def test_create_application_invalid_input(mocker):
 
     invalid_input_2 = create_application_input.copy()
     invalid_input_2["model"] = None
-    with pytest.raises(ValidationError) as exc_info:
+    # model=None is valid at Pydantic level (Optional), but validate_request
+    # raises CommonError when neither model nor agentRuntimeArn is provided
+    with pytest.raises(CommonError, match="Either model or agentRuntimeArn"):
         create_application(invalid_input_2)
-    error_messages = str(exc_info.value)
-    assert "Input should be a valid string" in error_messages
-    assert "type=string_type, input_value=None, input_type=NoneType" in error_messages
 
     invalid_input_3 = create_application_input.copy()
     invalid_input_3["roles"] = None
@@ -200,7 +231,7 @@ def test_create_application_invalid_input(mocker):
     assert "Input should be a valid list" in error_messages
     assert "type=list_type, input_value=None, input_type=NoneType" in error_messages
 
-    with pytest.raises(ValidationError, match="10 validation error"):
+    with pytest.raises(ValidationError, match="9 validation error"):
         create_application({})
 
     with pytest.raises(ValidationError, match="3 validation error"):
@@ -209,3 +240,85 @@ def test_create_application_invalid_input(mocker):
         invalid_input_4["systemPromptRag"] = ">"
         invalid_input_4["condenseSystemPrompt"] = ">"
         create_application(invalid_input_4)
+
+
+# --- Agent application tests ---
+
+
+def test_create_agent_application(mocker):
+    mock = mocker.patch(
+        "genai_core.applications.create_application", return_value=agent_application
+    )
+    mocker.patch("genai_core.auth.get_user_roles", return_value=["user", "admin"])
+
+    response = create_application(create_agent_application_input.copy())
+    assert response.get("id") == agent_application.get("Id")
+    assert response.get("agentRuntimeArn") == agent_application.get("AgentRuntimeArn")
+    assert response.get("model") is None
+    assert mock.call_count == 1
+    # Verify agentRuntimeArn was passed through
+    call_kwargs = mock.call_args
+    assert call_kwargs.kwargs["agentRuntimeArn"] == create_agent_application_input["agentRuntimeArn"]
+
+
+def test_update_agent_application(mocker):
+    mock = mocker.patch(
+        "genai_core.applications.update_application", return_value=agent_application
+    )
+    mocker.patch("genai_core.auth.get_user_roles", return_value=["user", "admin"])
+
+    update_input = create_agent_application_input.copy()
+    update_input["id"] = "agent_app_id"
+
+    response = update_application(update_input)
+    assert response.get("id") == agent_application.get("Id")
+    assert response.get("agentRuntimeArn") == agent_application.get("AgentRuntimeArn")
+    assert mock.call_count == 1
+
+
+def test_list_applications_includes_agent_arn(mocker):
+    mocker.patch(
+        "genai_core.applications.list_applications",
+        return_value=[application, agent_application],
+    )
+    mocker.patch("genai_core.auth.get_user_roles", return_value=["user", "admin"])
+
+    response = list_applications()
+    assert len(response) == 2
+    # Model-based app
+    assert response[0].get("agentRuntimeArn") is None
+    assert response[0].get("model") == "model"
+    # Agent-based app
+    assert response[1].get("agentRuntimeArn") == agent_application.get("AgentRuntimeArn")
+
+
+def test_get_agent_application(mocker):
+    mocker.patch(
+        "genai_core.applications.get_application", return_value=agent_application
+    )
+    mocker.patch("genai_core.auth.get_user_roles", return_value=["user", "admin"])
+
+    response = get_application("agent_app_id")
+    assert response.get("agentRuntimeArn") == agent_application.get("AgentRuntimeArn")
+    assert response.get("model") is None
+
+
+def test_create_application_no_model_no_agent(mocker):
+    """Neither model nor agent provided — should fail at validate_request"""
+    mocker.patch("genai_core.auth.get_user_roles", return_value=["user", "admin"])
+
+    invalid_input = create_agent_application_input.copy()
+    del invalid_input["agentRuntimeArn"]
+    # No model, no agent
+    with pytest.raises(CommonError, match="Either model or agentRuntimeArn"):
+        create_application(invalid_input)
+
+
+def test_create_application_invalid_agent_arn(mocker):
+    """Invalid ARN format should fail Pydantic or validate_request"""
+    mocker.patch("genai_core.auth.get_user_roles", return_value=["user", "admin"])
+
+    invalid_input = create_agent_application_input.copy()
+    invalid_input["agentRuntimeArn"] = "not-a-valid-arn"
+    with pytest.raises(CommonError, match="Invalid agent runtime ARN format"):
+        create_application(invalid_input)

--- a/tests/shared/layers/python-sdk/genai_core/applications_validate_test.py
+++ b/tests/shared/layers/python-sdk/genai_core/applications_validate_test.py
@@ -1,0 +1,77 @@
+import pytest
+from genai_core.types import CommonError
+
+VALID_AGENT_ARN = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent"
+
+
+def test_validate_request_valid_model(mocker):
+    mocker.patch(
+        "genai_core.models.list_models",
+        return_value=[{"provider": "bedrock", "name": "claude-v3"}],
+    )
+    mocker.patch("genai_core.roles.list_roles", return_value=[{"name": "admin"}])
+    from genai_core.applications import validate_request
+
+    validate_request(workspace=None, roles=["admin"], model="bedrock::claude-v3")
+
+
+def test_validate_request_valid_agent_arn(mocker):
+    mocker.patch("genai_core.roles.list_roles", return_value=[{"name": "admin"}])
+    from genai_core.applications import validate_request
+
+    validate_request(
+        workspace=None, roles=["admin"], model=None, agentRuntimeArn=VALID_AGENT_ARN
+    )
+
+
+def test_validate_request_invalid_agent_arn(mocker):
+    mocker.patch("genai_core.roles.list_roles", return_value=[{"name": "admin"}])
+    from genai_core.applications import validate_request
+
+    with pytest.raises(CommonError, match="Invalid agent runtime ARN format"):
+        validate_request(
+            workspace=None, roles=["admin"], model=None, agentRuntimeArn="not-an-arn"
+        )
+
+
+def test_validate_request_no_model_no_agent(mocker):
+    mocker.patch("genai_core.roles.list_roles", return_value=[{"name": "admin"}])
+    from genai_core.applications import validate_request
+
+    with pytest.raises(CommonError, match="Either model or agentRuntimeArn"):
+        validate_request(workspace=None, roles=["admin"], model=None)
+
+
+def test_validate_request_invalid_role(mocker):
+    mocker.patch("genai_core.roles.list_roles", return_value=[{"name": "admin"}])
+    from genai_core.applications import validate_request
+
+    with pytest.raises(CommonError, match="Role not found"):
+        validate_request(
+            workspace=None,
+            roles=["nonexistent"],
+            model=None,
+            agentRuntimeArn=VALID_AGENT_ARN,
+        )
+
+
+def test_validate_request_model_not_found(mocker):
+    mocker.patch("genai_core.models.list_models", return_value=[])
+    mocker.patch("genai_core.roles.list_roles", return_value=[{"name": "admin"}])
+    from genai_core.applications import validate_request
+
+    with pytest.raises(CommonError, match="Model not found"):
+        validate_request(workspace=None, roles=["admin"], model="bedrock::nonexistent")
+
+
+def test_validate_request_arn_injection_attempt(mocker):
+    mocker.patch("genai_core.roles.list_roles", return_value=[{"name": "admin"}])
+    from genai_core.applications import validate_request
+
+    with pytest.raises(CommonError, match="Invalid agent runtime ARN format"):
+        validate_request(
+            workspace=None,
+            roles=["admin"],
+            model=None,
+            agentRuntimeArn="arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/../../etc/passwd",
+        )


### PR DESCRIPTION
## Summary

Adds the ability for admins to configure an Application with an Amazon Bedrock AgentCore agent, optionally alongside a model and model settings. Regular users can then chat with agents through the Application interface.

## Changes

### Backend
- **GraphQL schema**: `agentRuntimeArn` field on `Application` type and `ManageApplicationInput`, `model` made nullable
- **genai_core/applications.py**: agent ARN validation (strict regex), model-or-agent-required logic in `validate_request`, agent ARN stored/returned in CRUD operations
- **routes/applications.py**: Pydantic models updated with `Optional[str]` model and `agentRuntimeArn` with ARN pattern validation
- **send-query-lambda-resolver**: routes agent-based applications to `modelInterface: "agent"` (set server-side), model-based to `langchain`. Passes `modelName`, `provider`, and `modelKwargs` to agent when configured
- **Bug fix**: `ConsiseSystemPrompt` → `CondenseSystemPrompt` typo in `update_application`

### Frontend
- Agent selector in application form (filters by `READY` status)
- Model and model settings remain available when agent is selected (agent receives them in payload)
- Dynamic `modelInterface` in chat-input-panel based on application config

### Testing
- **24 unit tests** (17 route-level + 7 validate_request including ARN injection attempt)
- **10 integration tests** (6 existing model-based + 4 agent: create, get, query with content verification, delete)

## How it works

1. Admin creates an Application, selects an AgentCore agent (and optionally a model + settings)
2. When a user sends a message through the Application, the send-query resolver sets `modelInterface: "agent"` server-side
3. SNS routes the message to the Bedrock Agents SQS queue
4. The Bedrock Agents Lambda invokes the agent via AgentCore with the full payload (including model info and kwargs)
5. Agent streams SSE responses back through the existing WebSocket pipeline
