### PR TITLE
fix: Upgrade aws-cdk CLI to 2.1124.1 for schema v53 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@types/node": "20.1.7",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
-        "aws-cdk": "^2.1025.0",
+        "aws-cdk": "^2.1124.1",
         "aws-xray-sdk-core": "3.10.1",
         "eslint": "^8.45.0",
         "eslint-config-prettier": "^9.1.0",
@@ -3854,17 +3854,15 @@
       "dev": true
     },
     "node_modules/aws-cdk": {
-      "version": "2.1025.0",
-      "integrity": "sha512-qKYM+RG5+U/UbGpjTt8ZaxBEfKJMPdOmtPtFNidsIGlrdIWSIFdNcFYi13zo33FkMk6ZFA6yBnjfDry3fNR+hQ==",
+      "version": "2.1124.1",
+      "integrity": "sha512-sRYdPMdkX+02EHaT946AFV0w0CMfbHKWpLZPv525xTCkaVu1eYu6DzHFuTdimxdSN0uGQ2D4LHrD1sr94tRhow==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
       },
       "engines": {
         "node": ">= 18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
       }
     },
     "node_modules/aws-cdk-lib": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@types/node": "20.1.7",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
-    "aws-cdk": "^2.1025.0",
+    "aws-cdk": "^2.1124.1",
     "aws-xray-sdk-core": "3.10.1",
     "eslint": "^8.45.0",
     "eslint-config-prettier": "^9.1.0",


### PR DESCRIPTION
aws-cdk-lib 2.256.0 produces cloud assembly schema v53 which requires CDK CLI >= 2.1124.0. The previous pin at ^2.1025.0 resolved to a version that only supports up to schema 48.x.x, causing deploy failures.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
