### PR TITLE
fix: Bump Aurora PostgreSQL from 15.10 to 15.15

### DIFF
--- a/lib/rag-engines/aurora-pgvector/index.ts
+++ b/lib/rag-engines/aurora-pgvector/index.ts
@@ -36,7 +36,7 @@ export class AuroraPgVector extends Construct {
       engine: rds.DatabaseClusterEngine.auroraPostgres({
         // Extensions version per engine
         // https://docs.aws.amazon.com/AmazonRDS/latest/AuroraPostgreSQLReleaseNotes/AuroraPostgreSQL.Extensions.html
-        version: rds.AuroraPostgresEngineVersion.VER_15_10,
+        version: rds.AuroraPostgresEngineVersion.VER_15_15,
       }),
       storageEncryptionKey: props.shared.kmsKey,
       // Always setting it to true would be a breaking change. (Undefined to prevent re-creating)


### PR DESCRIPTION
AWS auto-patched the deployed cluster to 15.15. RDS rejects downgrades, so the CDK template must match the running version.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
