### PR TITLE
fix: Bump Aurora PostgreSQL from 15.10 to 15.15

### DIFF
--- a/tests/__snapshots__/cdk-app.test.ts.snap
+++ b/tests/__snapshots__/cdk-app.test.ts.snap
@@ -8650,7 +8650,7 @@ schema {
         },
         "EnableIAMDatabaseAuthentication": true,
         "Engine": "aurora-postgresql",
-        "EngineVersion": "15.10",
+        "EngineVersion": "15.15",
         "KmsKeyId": {
           "Fn::GetAtt": [
             "SharedKMSKey7BCBB616",

--- a/tests/chatbot-api/__snapshots__/chatbot-api-construct.test.ts.snap
+++ b/tests/chatbot-api/__snapshots__/chatbot-api-construct.test.ts.snap
@@ -5562,7 +5562,7 @@ schema {
         },
         "EnableIAMDatabaseAuthentication": true,
         "Engine": "aurora-postgresql",
-        "EngineVersion": "15.10",
+        "EngineVersion": "15.15",
         "MasterUserPassword": {
           "Fn::Join": [
             "",


### PR DESCRIPTION
AWS auto-patched the deployed cluster to 15.15. RDS rejects downgrades, so the CDK template must match the running version.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
