### PR TITLE
fix: Update default integ test model to Claude Haiku 4.5

### DIFF
--- a/integtests/chatbot-api/application_test.py
+++ b/integtests/chatbot-api/application_test.py
@@ -16,7 +16,7 @@ def test_create_application(client: AppSyncClient):
     pytest.application = client.create_application(
         input={
             "name": "INTEG_TEST_APP",
-            "model": "bedrock::anthropic.claude-3-haiku-20240307-v1:0",
+            "model": "bedrock::us.anthropic.claude-haiku-4-5-20251001-v1:0",
             "roles": ["user"],
             "allowImageInput": True,
             "allowVideoInput": True,
@@ -103,7 +103,7 @@ def test_update_application(client: AppSyncClient):
         input={
             "id": pytest.application.get("id"),
             "name": "INTEG_TEST_APP",
-            "model": "bedrock::anthropic.claude-3-haiku-20240307-v1:0",
+            "model": "bedrock::us.anthropic.claude-haiku-4-5-20251001-v1:0",
             "roles": ["user", "admin"],
             "allowImageInput": False,
             "allowVideoInput": False,

--- a/integtests/chatbot-api/model_test.py
+++ b/integtests/chatbot-api/model_test.py
@@ -6,7 +6,7 @@ def test_list_models(client: AppSyncClient, default_model):
     assert len(models) > 10
     model = next(i for i in models if i.get("name") == default_model)
     assert model == {
-        "name": "anthropic.claude-3-haiku-20240307-v1:0",
+        "name": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
         "provider": "bedrock",
         "interface": "langchain",
         "ragSupported": True,

--- a/integtests/chatbot-api/test_agent_conversation_flow.py
+++ b/integtests/chatbot-api/test_agent_conversation_flow.py
@@ -56,7 +56,7 @@ def test_agent_conversation_single_turn(
             "documents": [],
             "images": [],
             "videos": [],
-            "modelName": "anthropic.claude-3-haiku-20240307-v1:0",
+            "modelName": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
             "provider": "bedrock",
             "modelKwargs": {
                 "streaming": False,
@@ -98,7 +98,7 @@ def test_agent_conversation_multi_turn(
             "documents": [],
             "images": [],
             "videos": [],
-            "modelName": "anthropic.claude-3-haiku-20240307-v1:0",
+            "modelName": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
             "provider": "bedrock",
             "modelKwargs": {
                 "streaming": False,
@@ -126,7 +126,7 @@ def test_agent_conversation_multi_turn(
             "documents": [],
             "images": [],
             "videos": [],
-            "modelName": "anthropic.claude-3-haiku-20240307-v1:0",
+            "modelName": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
             "provider": "bedrock",
             "modelKwargs": {
                 "streaming": False,
@@ -161,7 +161,7 @@ def test_agent_conversation_error_handling(client: AppSyncClient, agent_session_
             "documents": [],
             "images": [],
             "videos": [],
-            "modelName": "anthropic.claude-3-haiku-20240307-v1:0",
+            "modelName": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
             "provider": "bedrock",
             "modelKwargs": {
                 "streaming": False,
@@ -212,7 +212,7 @@ def test_agent_conversation_session_persistence(
                 "documents": [],
                 "images": [],
                 "videos": [],
-                "modelName": "anthropic.claude-3-haiku-20240307-v1:0",
+                "modelName": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
                 "provider": "bedrock",
                 "modelKwargs": {
                     "streaming": False,
@@ -257,7 +257,7 @@ def test_agent_conversation_cleanup(client: AppSyncClient, available_agent):
             "documents": [],
             "images": [],
             "videos": [],
-            "modelName": "anthropic.claude-3-haiku-20240307-v1:0",
+            "modelName": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
             "provider": "bedrock",
             "modelKwargs": {
                 "streaming": False,

--- a/integtests/conftest.py
+++ b/integtests/conftest.py
@@ -70,7 +70,7 @@ def unauthenticated_client(config):
 
 @pytest.fixture(scope="session")
 def default_model():
-    return "anthropic.claude-3-haiku-20240307-v1:0"
+    return "us.anthropic.claude-haiku-4-5-20251001-v1:0"
 
 
 @pytest.fixture(scope="session")
@@ -80,7 +80,7 @@ def default_embed_model():
 
 @pytest.fixture(scope="session")
 def default_multimodal_model():
-    return "anthropic.claude-3-haiku-20240307-v1:0"
+    return "us.anthropic.claude-haiku-4-5-20251001-v1:0"
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Claude 3 Haiku (anthropic.claude-3-haiku-20240307-v1:0) has been retired by AWS Bedrock as a legacy model. Replace with Claude Haiku 4.5 via cross-region inference profile (us.anthropic.claude-haiku-4-5- 20251001-v1:0) which is actively supported.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
