### PR TITLE
fix: Add SQS encryption to bedrock-agents queues

### DIFF
--- a/lib/model-interfaces/bedrock-agents/index.ts
+++ b/lib/model-interfaces/bedrock-agents/index.ts
@@ -35,10 +35,20 @@ export class BedrockAgentsInterface extends Construct {
     const ingestionQueue = new sqs.Queue(this, "IngestionQueue", {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
       visibilityTimeout: cdk.Duration.minutes(16),
+      encryption: props.shared.kmsKey
+        ? sqs.QueueEncryption.KMS
+        : sqs.QueueEncryption.SQS_MANAGED,
+      encryptionMasterKey: props.shared.kmsKey,
+      enforceSSL: true,
       deadLetterQueue: {
         maxReceiveCount: 3,
         queue: new sqs.Queue(this, "IngestionDLQ", {
           removalPolicy: cdk.RemovalPolicy.DESTROY,
+          encryption: props.shared.kmsKey
+            ? sqs.QueueEncryption.KMS
+            : sqs.QueueEncryption.SQS_MANAGED,
+          encryptionMasterKey: props.shared.kmsKey,
+          enforceSSL: true,
         }),
       },
     });

--- a/tests/__snapshots__/cdk-app.test.ts.snap
+++ b/tests/__snapshots__/cdk-app.test.ts.snap
@@ -642,8 +642,49 @@ exports[`snapshot test with CMK 1`] = `
           ],
         },
       },
+      "Properties": {
+        "KmsMasterKeyId": {
+          "Fn::GetAtt": [
+            "SharedKMSKey7BCBB616",
+            "Arn",
+          ],
+        },
+      },
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
+    },
+    "BedrockAgentsInterfaceIngestionDLQPolicy50A62F61": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sqs:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*",
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "BedrockAgentsInterfaceIngestionDLQ5FCC542B",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Queues": [
+          {
+            "Ref": "BedrockAgentsInterfaceIngestionDLQ5FCC542B",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::QueuePolicy",
     },
     "BedrockAgentsInterfaceIngestionQueueDA7BCA4C": {
       "DeletionPolicy": "Delete",
@@ -658,6 +699,12 @@ exports[`snapshot test with CMK 1`] = `
         },
       },
       "Properties": {
+        "KmsMasterKeyId": {
+          "Fn::GetAtt": [
+            "SharedKMSKey7BCBB616",
+            "Arn",
+          ],
+        },
         "RedrivePolicy": {
           "deadLetterTargetArn": {
             "Fn::GetAtt": [
@@ -676,6 +723,24 @@ exports[`snapshot test with CMK 1`] = `
       "Properties": {
         "PolicyDocument": {
           "Statement": [
+            {
+              "Action": "sqs:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*",
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "BedrockAgentsInterfaceIngestionQueueDA7BCA4C",
+                  "Arn",
+                ],
+              },
+            },
             {
               "Action": "sqs:SendMessage",
               "Condition": {
@@ -917,6 +982,16 @@ exports[`snapshot test with CMK 1`] = `
               "Resource": {
                 "Fn::GetAtt": [
                   "BedrockAgentsInterfaceIngestionQueueDA7BCA4C",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": "kms:Decrypt",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "SharedKMSKey7BCBB616",
                   "Arn",
                 ],
               },
@@ -19649,6 +19724,17 @@ schema {
                     "Arn",
                   ],
                 },
+              },
+              "Resource": "*",
+            },
+            {
+              "Action": [
+                "kms:Decrypt",
+                "kms:GenerateDataKey",
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "sns.amazonaws.com",
               },
               "Resource": "*",
             },


### PR DESCRIPTION
Add SQS_MANAGED encryption (or KMS when CMKs enabled) to the IngestionQueue and IngestionDLQ in bedrock-agents model interface. Resolves SonarQube security hotspot typescript:S6330.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
