### PR TITLE
fix(integ): Clean up errored workspaces in aurora test fixture

### DIFF
--- a/integtests/chatbot-api/aurora_workspace_test.py
+++ b/integtests/chatbot-api/aurora_workspace_test.py
@@ -11,7 +11,7 @@ def run_before_and_after_tests(client: AppSyncClient):
         if (
             workspace.get("name") == "INTEG_TEST_AURORA"
             or workspace.get("name") == "INTEG_TEST_AURORA_WITHOUT_RERANK"
-        ) and workspace.get("status") == "ready":
+        ) and workspace.get("status") in ("ready", "error"):
             client.delete_workspace(workspace.get("id"))
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7864,8 +7864,8 @@
       "peer": true
     },
     "node_modules/semver": {
-      "version": "7.8.0",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.1",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "dev": true,
       "license": "ISC",
       "bin": {


### PR DESCRIPTION
The test fixture only deleted workspaces with status 'ready', leaving errored workspaces and their pending rssposts in DynamoDB. These orphaned posts clogged the batch_crawl_websites queue (10 per invocation), causing test_search_document_no_reank to timeout waiting for its posts to be processed.

Now also deletes workspaces in 'error' state to prevent backlog accumulation across test runs.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
