### PR TITLE
fix: Stabilize UI integ tests 

### DIFF
--- a/integtests/user_interface/react_app/pages/models.py
+++ b/integtests/user_interface/react_app/pages/models.py
@@ -1,4 +1,6 @@
 from pages.dom import DomOperator
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
 
 
 class ModelsPage(object):
@@ -7,6 +9,31 @@ class ModelsPage(object):
         self.dom_operator = DomOperator(driver)
 
     def find_model(self, name):
+        # Narrow the (paginated) Models table via the PropertyFilter so the
+        # target row is on the visible page regardless of how many Bedrock
+        # base/CRIS/sagemaker entries the account exposes.
+        filter_input = self.dom_operator.getByPath(
+            "//input[@placeholder='Filter Models']",
+            wait=10,
+        )
+        if filter_input != False:
+            # PropertyFilter commits typed text into a token chip on Enter,
+            # and input.clear() does not remove existing chips. Dismiss any
+            # tokens left over from previous find_model() calls before
+            # applying the new one.
+            for token in self.driver.find_elements(
+                By.XPATH,
+                "//button[starts-with(@aria-label,'Remove token')]",
+            ):
+                try:
+                    token.click()
+                except Exception:
+                    pass
+
+            filter_input.clear()
+            filter_input.send_keys(name)
+            filter_input.send_keys(Keys.ENTER)
+
         dom = self.dom_operator.getByPath(
             f"//th//div[contains(text(),'{name}')]",
             wait=25,

--- a/integtests/user_interface/react_app/pages/sessions.py
+++ b/integtests/user_interface/react_app/pages/sessions.py
@@ -19,9 +19,24 @@ class SessionsPage(object):
 
         dom = self.dom_operator.getByPath(
             "//b[contains(text(),'No sessions')]",
-            wait=25,
+            wait=60,
         )
         assert dom != False
+
+        # Wait for the confirm modal's closing overlay to fully detach so
+        # that subsequent clicks on the page chrome are not intercepted.
+        from selenium.webdriver.support.ui import WebDriverWait
+        from selenium.webdriver.common.by import By
+        from selenium.common.exceptions import TimeoutException
+
+        try:
+            WebDriverWait(self.driver, 10).until(
+                lambda d: not d.find_elements(
+                    By.XPATH, "//*[@data-locator='confirm-delete-all']"
+                )
+            )
+        except TimeoutException:
+            pass
 
     def open_session(self, name):
         dom = self.dom_operator.getByPath(

--- a/integtests/user_interface/react_app/test_playground.py
+++ b/integtests/user_interface/react_app/test_playground.py
@@ -5,7 +5,12 @@ from pages.playground import PlaygroundPage
 import time
 
 
-def test_playground(selenium_driver, cognito_admin_credentials, default_model):
+def test_playground(selenium_driver, cognito_admin_credentials, default_model, client):
+    # Pre-clean any sessions left over from prior test runs via the AppSync
+    # API so the UI delete-all flow has a small, predictable workload and
+    # the empty-state poll completes within the test timeout.
+    client.delete_user_sessions()
+
     login = LoginPage(selenium_driver)
     layout = Layout(selenium_driver)
 


### PR DESCRIPTION
### Why
Two UI tests started failing in the pipeline because the Models table is paginated, so the target row isn't in the DOM on the first page and the XPath wait times out.

- `test_models` —  default Haiku 4.5 isn't on the first page of the Models table, so the XPath wait never finds the row.
- `test_playground` — UI delete-all flow has accumulated sessions and times out before the empty state renders.

### Fix
- `pages/models.py`: Use the existing PropertyFilter to narrow the table to the target model name before asserting on the row.
- `pages/sessions.py`: Bump empty-state wait to 60s and wait for the modal to close before returning.
- `test_playground.py`: Pre-clean sessions over the AppSync API before exercising the UI delete-all flow.

### Verification
Ran `HEADLESS=1 pytest integtests/user_interface -s -vv` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
