### PR TITLE
fix: Bump PyJWT to 2.13.0 to clear pip-audit failures

### DIFF
--- a/lib/shared/file-import-batch-job/requirements.txt
+++ b/lib/shared/file-import-batch-job/requirements.txt
@@ -15,5 +15,5 @@ beautifulsoup4==4.12.2
 requests==2.32.5
 attrs==23.1.0
 feedparser==6.0.11
-PyJWT==2.9.0
+PyJWT==2.13.0
 pdfminer-six==20251107


### PR DESCRIPTION
PyJWT 2.9.0 had 5 unfixable-via-ignore vulnerabilities flagged by pip-audit (PYSEC-2026-175 through PYSEC-2026-179). Bumping to 2.13.0 clears all of them.

Verified via:
  pip-audit -r lib/shared/file-import-batch-job/requirements.txt

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
