### PR TITLE
fix: Fix automatic Cognito group assignment for federated users

### DIFF
--- a/.pip-audit-known-vulns
+++ b/.pip-audit-known-vulns
@@ -6,6 +6,7 @@ GHSA-pjwx-r37v-7724
 PYSEC-2026-77
 PYSEC-2024-278
 PYSEC-2026-76
+GHSA-gr75-jv2w-4656
 
 # cryptography/pyopenssl - pinned by transitive deps
 PYSEC-2026-35

--- a/integtests/user_interface/react_app/test_workspace.py
+++ b/integtests/user_interface/react_app/test_workspace.py
@@ -16,9 +16,10 @@ def test_workspace(selenium_driver, cognito_admin_credentials, client):
 
     # cleanup
     for workspace in client.list_workspaces():
-        if (workspace.get("name") == "TEST_UI_AURORA") and workspace.get(
-            "status"
-        ) == "ready":
+        if (workspace.get("name") == "TEST_UI_AURORA") and workspace.get("status") in (
+            "ready",
+            "error",
+        ):
             client.delete_workspace(workspace.get("id"))
 
     login = LoginPage(selenium_driver)

--- a/lib/authentication/index.ts
+++ b/lib/authentication/index.ts
@@ -52,14 +52,14 @@ export class Authentication extends Construct {
       getConstructId("WorkspaceManagerGroup", config),
       {
         userPoolId: userPool.userPoolId,
-        groupName: getConstructId("workspace_manager", config),
+        groupName: "workspace_manager",
         description: "Workspace managers group",
       }
     );
 
     new cognito.CfnUserPoolGroup(this, "UserGroup", {
       userPoolId: userPool.userPoolId,
-      groupName: getConstructId("user", config),
+      groupName: "user",
       description: "User group",
     });
 
@@ -314,7 +314,7 @@ export class Authentication extends Construct {
           logRetention: config.logRetention ?? logs.RetentionDays.ONE_WEEK,
           loggingFormat: lambda.LoggingFormat.JSON,
           environment: {
-            DEFAULT_USER_GROUP: getConstructId("user", config),
+            DEFAULT_USER_GROUP: "user",
           },
         }
       );
@@ -341,6 +341,19 @@ export class Authentication extends Construct {
       );
       userPool.addTrigger(
         cognito.UserPoolOperation.POST_CONFIRMATION,
+        addFederatedUserToUserGroupLambda
+      );
+
+      // POST_CONFIRMATION does not fire for federated users; PRE_TOKEN_GENERATION fires on every sign-in, so use it to assign the group.
+      addFederatedUserToUserGroupLambda.addPermission(
+        "CognitoPreTokenGenerationTrigger",
+        {
+          principal: new iam.ServicePrincipal("cognito-idp.amazonaws.com"),
+          sourceArn: userPool.userPoolArn,
+        }
+      );
+      userPool.addTrigger(
+        cognito.UserPoolOperation.PRE_TOKEN_GENERATION,
         addFederatedUserToUserGroupLambda
       );
 

--- a/lib/authentication/lambda/addFederatedUserToUserGroup/index.py
+++ b/lib/authentication/lambda/addFederatedUserToUserGroup/index.py
@@ -70,54 +70,49 @@ def add_user_to_group(cognito, username, group_name, user_pool_id):
             raise e
 
 
+def override_token_groups(event, group_name):
+    """Override the token's cognito:groups claim so the first federated token is correct."""  # noqa: E501
+    response = event.setdefault("response", {})
+    claims_override = response.get("claimsOverrideDetails") or {}
+    claims_override["groupOverrideDetails"] = {"groupsToOverride": [group_name]}
+    response["claimsOverrideDetails"] = claims_override
+    print(f"Overriding token groups with: [{group_name}]")
+    return event
+
+
 def handler(event, context):
     print(f"Event received: {event}")
 
-    # Handle different trigger types with different event structures
-    if "request" in event and "userAttributes" in event["request"]:
-        # POST_AUTHENTICATION trigger
-        user_attributes = event["request"]["userAttributes"]
-        username = user_attributes.get("sub") or user_attributes.get("username")
-        new_group = user_attributes.get("custom:chatbot_role")
-        user_pool_id = event["userPoolId"]
-        trigger_type = "POST_AUTHENTICATION"
-    elif "userAttributes" in event:
-        # PRE_AUTHENTICATION trigger
-        user_attributes = event["userAttributes"]
-        username = user_attributes.get("sub")
-        new_group = user_attributes.get("custom:chatbot_role")
-        user_pool_id = event["userPoolId"]
-        trigger_type = "PRE_AUTHENTICATION"
-    elif (
-        "request" in event
-        and "userAttributes" in event["request"]
-        and "validationData" in event["request"]
-    ):
-        # POST_CONFIRMATION trigger
-        user_attributes = event["request"]["userAttributes"]
-        username = user_attributes.get("sub") or user_attributes.get("username")
-        new_group = user_attributes.get("custom:chatbot_role")
-        user_pool_id = event["userPoolId"]
+    # Determine the trigger type from triggerSource (event shapes overlap).
+    trigger_source = event.get("triggerSource", "")
+
+    if trigger_source.startswith("TokenGeneration_"):
+        trigger_type = "PRE_TOKEN_GENERATION"
+    elif trigger_source.startswith("PostConfirmation_"):
         trigger_type = "POST_CONFIRMATION"
-    elif (
-        "request" in event
-        and "userAttributes" in event["request"]
-        and "validationData" not in event["request"]
-    ):
-        # PRE_SIGN_UP trigger
-        user_attributes = event["request"]["userAttributes"]
-        # For Pre sign-up, username might be in different fields
-        username = (
-            user_attributes.get("sub")
-            or user_attributes.get("username")
-            or user_attributes.get("email")
-        )
-        new_group = user_attributes.get("custom:chatbot_role")
-        user_pool_id = event["userPoolId"]
+    elif trigger_source.startswith("PreSignUp_"):
         trigger_type = "PRE_SIGN_UP"
+    elif trigger_source.startswith("PostAuthentication_"):
+        trigger_type = "POST_AUTHENTICATION"
+    elif trigger_source.startswith("PreAuthentication_"):
+        trigger_type = "PRE_AUTHENTICATION"
     else:
+        print(f"Unhandled trigger source: {trigger_source}")
+        return event
+
+    user_attributes = event.get("request", {}).get("userAttributes", {})
+    if not user_attributes:
         print("No user attributes found in event")
         return event
+
+    # Cognito provides the username at the top level of the event.
+    username = (
+        event.get("userName")
+        or user_attributes.get("sub")
+        or user_attributes.get("email")
+    )
+    new_group = user_attributes.get("custom:chatbot_role")
+    user_pool_id = event["userPoolId"]
 
     print(f"Trigger type: {trigger_type}")
     print(f"User attributes: {user_attributes}")
@@ -133,29 +128,22 @@ def handler(event, context):
         new_group = default_group
         print(f"No custom:chatbot_role found, using default group: {default_group}")
 
-    # For Pre sign-up, we cannot assign groups because the user doesn't exist yet
+    # PRE_SIGN_UP fires before the federated user exists, so we cannot assign
+    # groups here. The actual assignment happens on PRE_TOKEN_GENERATION, which
+    # runs after the user is created and on every subsequent sign-in.
     if trigger_type == "PRE_SIGN_UP":
-        print("Pre sign-up trigger - user will be created after this trigger completes")
-        print(f"Will assign user to group: {new_group}")
-        print(
-            "Note: Group assignment will happen in a separate \
-            trigger (POST_CONFIRMATION)"
-        )
+        print("Pre sign-up trigger - user does not exist yet; deferring assignment")
+        print(f"Resolved group for later assignment: {new_group}")
 
-        # For Pre sign-up, we can only validate or modify the sign-up request
-        # We cannot assign groups yet as the user doesn't exist
-        # The group assignment will need to happen in
-        # POST_CONFIRMATION or PRE_AUTHENTICATION
-
-        # You might want to add the group information to the user attributes
-        # so it can be used later in POST_CONFIRMATION
+        # Persist the resolved group on the attribute so it is available later.
         if "custom:chatbot_role" not in user_attributes:
             user_attributes["custom:chatbot_role"] = new_group
             print(f"Added custom:chatbot_role attribute: {new_group}")
 
         return event
 
-    # For other triggers (PRE_AUTHENTICATION, POST_AUTHENTICATION, POST_CONFIRMATION)
+    # For triggers where the user already exists
+    # (POST_CONFIRMATION, POST_AUTHENTICATION, PRE_TOKEN_GENERATION).
     if username:
         cognito = boto3.client("cognito-idp")
 
@@ -180,6 +168,10 @@ def handler(event, context):
             )
         else:
             print(f"User {username} is already in group {new_group}")
+
+        # For Pre Token Generation, override the groups claim so the first token is correct.  # noqa: E501
+        if trigger_type == "PRE_TOKEN_GENERATION":
+            event = override_token_groups(event, new_group)
     else:
         print("No username found in user attributes, skipping group assignment")
 

--- a/lib/user-interface/react-app/package-lock.json
+++ b/lib/user-interface/react-app/package-lock.json
@@ -8,7 +8,6 @@
       "name": "aws-genai-llm-chatbot",
       "version": "3.0.0",
       "dependencies": {
-        "@aws-amplify/datastore": "^4.7.22",
         "@aws-amplify/ui-react": "^5.3.3",
         "@cloudscape-design/chat-components": "1.0.17",
         "@cloudscape-design/component-toolkit": "1.0.0-beta.80",
@@ -18,7 +17,7 @@
         "@fortawesome/fontawesome-svg-core": "^6.4.2",
         "@fortawesome/free-solid-svg-icons": "^6.4.2",
         "@fortawesome/react-fontawesome": "^0.2.0",
-        "aws-amplify": "^5.3.20",
+        "aws-amplify": "5.3.33",
         "luxon": "^3.4.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/lib/user-interface/react-app/package-lock.json
+++ b/lib/user-interface/react-app/package-lock.json
@@ -8,6 +8,7 @@
       "name": "aws-genai-llm-chatbot",
       "version": "3.0.0",
       "dependencies": {
+        "@aws-amplify/datastore": "^4.7.22",
         "@aws-amplify/ui-react": "^5.3.3",
         "@cloudscape-design/chat-components": "1.0.17",
         "@cloudscape-design/component-toolkit": "1.0.0-beta.80",

--- a/lib/user-interface/react-app/package.json
+++ b/lib/user-interface/react-app/package.json
@@ -12,6 +12,7 @@
     "format": "npx prettier --ignore-path .gitignore --write \"**/*.+(tsx|js|ts|json)\""
   },
   "dependencies": {
+    "@aws-amplify/datastore": "^4.7.22",
     "@aws-amplify/ui-react": "^5.3.3",
     "@cloudscape-design/chat-components": "1.0.17",
     "@cloudscape-design/component-toolkit": "1.0.0-beta.80",

--- a/lib/user-interface/react-app/package.json
+++ b/lib/user-interface/react-app/package.json
@@ -12,7 +12,6 @@
     "format": "npx prettier --ignore-path .gitignore --write \"**/*.+(tsx|js|ts|json)\""
   },
   "dependencies": {
-    "@aws-amplify/datastore": "^4.7.22",
     "@aws-amplify/ui-react": "^5.3.3",
     "@cloudscape-design/chat-components": "1.0.17",
     "@cloudscape-design/component-toolkit": "1.0.0-beta.80",
@@ -22,7 +21,7 @@
     "@fortawesome/fontawesome-svg-core": "^6.4.2",
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
-    "aws-amplify": "^5.3.20",
+    "aws-amplify": "5.3.33",
     "luxon": "^3.4.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7864,8 +7864,8 @@
       "peer": true
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/pytest_requirements.txt
+++ b/pytest_requirements.txt
@@ -10,8 +10,8 @@ black==24.8.0
 flake8==7.1.0
 selenium==4.16
 pdfplumber==0.11.8
-pyopenssl==24.3.0
-cryptography==44.0.1
+pyopenssl==26.3.0
+cryptography==49.0.0
 urllib3==2.6.0
 langchain-core==0.3.80
 pdfminer.six==20251107

--- a/tests/authentication/lambda/addFederatedUserToGroup_test.py
+++ b/tests/authentication/lambda/addFederatedUserToGroup_test.py
@@ -24,6 +24,8 @@ from index import (  # noqa: E402
 @pytest.fixture
 def cognito_event():
     return {
+        "triggerSource": "TokenGeneration_HostedAuth",
+        "userName": "EntraID_test-user-123",
         "request": {
             "userAttributes": {
                 "sub": "test-user-123",
@@ -93,6 +95,8 @@ def test_remove_user_from_group_success(mock_cognito):
 
 def test_handler_new_group_assignment(mock_cognito):
     event = {
+        "triggerSource": "PostAuthentication_Authentication",
+        "userName": "test-user-123",
         "request": {
             "userAttributes": {
                 "sub": "test-user-123",
@@ -115,6 +119,8 @@ def test_handler_new_group_assignment(mock_cognito):
 
 def test_handler_no_group_change(mock_cognito):
     event = {
+        "triggerSource": "PostAuthentication_Authentication",
+        "userName": "test-user-123",
         "request": {
             "userAttributes": {
                 "sub": "test-user-123",
@@ -137,6 +143,8 @@ def test_handler_no_group_change(mock_cognito):
 
 def test_handler_no_chatbot_role(mock_cognito):
     event = {
+        "triggerSource": "PostAuthentication_Authentication",
+        "userName": "test-user-123",
         "request": {"userAttributes": {"sub": "test-user-123"}},
         "userPoolId": "us-east-1_testpool",
     }
@@ -157,3 +165,119 @@ def test_handler_no_chatbot_role(mock_cognito):
         Username="test-user-123",
         GroupName="user",  # default group
     )
+
+
+def test_handler_pre_sign_up_does_not_assign(mock_cognito):
+    # PRE_SIGN_UP fires for federated users but cannot assign groups yet,
+    # so it must return early without calling the admin APIs.
+    event = {
+        "triggerSource": "PreSignUp_ExternalProvider",
+        "userName": "EntraID_test-user-123",
+        "request": {
+            "userAttributes": {
+                "email": "user@example.com",
+                "custom:chatbot_role": "workspace_manager",
+            }
+        },
+        "userPoolId": "us-east-1_testpool",
+    }
+
+    result = handler(event, None)
+
+    assert result == event
+    mock_cognito.admin_add_user_to_group.assert_not_called()
+    mock_cognito.admin_remove_user_from_group.assert_not_called()
+
+
+def test_handler_unknown_trigger_source_returns_early(mock_cognito):
+    event = {
+        "request": {
+            "userAttributes": {
+                "sub": "test-user-123",
+                "custom:chatbot_role": "workspace_manager",
+            }
+        },
+        "userPoolId": "us-east-1_testpool",
+    }
+
+    result = handler(event, None)
+
+    assert result == event
+    mock_cognito.admin_list_groups_for_user.assert_not_called()
+    mock_cognito.admin_add_user_to_group.assert_not_called()
+
+
+def test_handler_uses_username_over_sub(mock_cognito):
+    # Cognito delivers the username at the top level as "userName"; it must
+    # take precedence over sub when calling the admin APIs.
+    event = {
+        "triggerSource": "PostAuthentication_Authentication",
+        "userName": "EntraID_top-level-name",
+        "request": {
+            "userAttributes": {
+                "sub": "test-user-123",
+                "custom:chatbot_role": "workspace_manager",
+            }
+        },
+        "userPoolId": "us-east-1_testpool",
+    }
+
+    mock_cognito.admin_list_groups_for_user.return_value = {"Groups": []}
+
+    handler(event, None)
+
+    mock_cognito.admin_add_user_to_group.assert_called_once_with(
+        UserPoolId="us-east-1_testpool",
+        Username="EntraID_top-level-name",
+        GroupName="workspace_manager",
+    )
+
+
+def test_handler_pre_token_generation_overrides_claim(mock_cognito):
+    # PRE_TOKEN_GENERATION persists membership AND overrides the token's
+    # groups claim so the first federated token is correct.
+    event = {
+        "triggerSource": "TokenGeneration_HostedAuth",
+        "userName": "EntraID_test-user-123",
+        "request": {
+            "userAttributes": {
+                "sub": "test-user-123",
+                "custom:chatbot_role": "workspace_manager",
+            }
+        },
+        "userPoolId": "us-east-1_testpool",
+    }
+
+    mock_cognito.admin_list_groups_for_user.return_value = {"Groups": []}
+
+    result = handler(event, None)
+
+    mock_cognito.admin_add_user_to_group.assert_called_once_with(
+        UserPoolId="us-east-1_testpool",
+        Username="EntraID_test-user-123",
+        GroupName="workspace_manager",
+    )
+    assert result["response"]["claimsOverrideDetails"]["groupOverrideDetails"][
+        "groupsToOverride"
+    ] == ["workspace_manager"]
+
+
+def test_handler_non_token_trigger_does_not_override_claim(mock_cognito):
+    # Only PRE_TOKEN_GENERATION should set claimsOverrideDetails.
+    event = {
+        "triggerSource": "PostAuthentication_Authentication",
+        "userName": "test-user-123",
+        "request": {
+            "userAttributes": {
+                "sub": "test-user-123",
+                "custom:chatbot_role": "workspace_manager",
+            }
+        },
+        "userPoolId": "us-east-1_testpool",
+    }
+
+    mock_cognito.admin_list_groups_for_user.return_value = {"Groups": []}
+
+    result = handler(event, None)
+
+    assert "response" not in result


### PR DESCRIPTION

## Fix automatic Cognito group assignment for federated users

Federated (SAML/OIDC) users weren't being added to the Cognito group from their `custom:chatbot_role` attribute, so admins had to assign groups manually.

**Cause:** the assignment Lambda only ran on `POST_CONFIRMATION`, which never fires for federated users.

**Fix:**
- Run the Lambda on `PRE_TOKEN_GENERATION` (fires on every sign-in), which persists the group and overrides the token's `cognito:groups` claim so the first token is correct.
- Detect trigger type via `triggerSource` and read the username from `event["userName"]`.
- Use bare group names (`workspace_manager`, `user`) to match the app's authorization checks.

**Tests:** updated and added unit tests for the Lambda (13 passing). `tsc`, `jest`, and `flake8` all clean.

--

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
